### PR TITLE
 Engage base64encoded username as the UserId in association APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/AssociationEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/AssociationEndpointConstants.java
@@ -20,8 +20,43 @@ package org.wso2.carbon.identity.rest.api.user.association.v1;
  */
 public class AssociationEndpointConstants {
 
-    public static final String ASSOCIATION_ERROR_PREFIX = "UAA";
+    public static final String ASSOCIATION_ERROR_PREFIX = "UAA-";
     public static final String V1_API_PATH_COMPONENT = "/v1";
     public static final String USER_ASSOCIATIONS_PATH_COMPONENT = "/%s/associations";
     public static final String ME_CONTEXT = "me";
+    public static final String ERROR_MSG_DELIMITER = "-";
+
+    public enum ErrorMessages {
+
+        ERROR_CODE_PW_MANDATORY("8900", "Invalid Inputs", "Password is a missing in the request");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessages(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+            return ASSOCIATION_ERROR_PREFIX + code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public String toString() {
+            return getCode() + " | " + getMessage() + " | " + getDescription();
+        }
+
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.2.6</identity.governance.version>
         <carbon.identity.framework.version>5.13.8</carbon.identity.framework.version>
-        <carbon.identity.account.association.version>5.2.2</carbon.identity.account.association.version>
+        <carbon.identity.account.association.version>5.2.3</carbon.identity.account.association.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Purpose
>  Engage base64encoded username as the UserId in association APIs

As part of the feature: https://github.com/wso2/product-is/issues/5889