### PR TITLE
Add Session managament API implementation

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.common/pom.xml
@@ -24,7 +24,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.wso2.carbon.identity.user.api</groupId>
     <artifactId>org.wso2.carbon.identity.api.user.common</artifactId>
     <packaging>jar</packaging>
 

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
@@ -16,18 +16,30 @@
 
 package org.wso2.carbon.identity.api.user.common;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.user.common.error.APIError;
+import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
+import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 
 import java.util.UUID;
+import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.user.common.Constants.CORRELATION_ID_MDC;
+import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.ERROR_CODE_INVALID_USERNAME;
 
 /**
  * Common util class
  */
 public class Util {
+
+    private static final Log log = LogFactory.getLog(Util.class);
 
     /**
      * Get ChallengeQuestionManager osgi service
@@ -59,5 +71,26 @@ public class Util {
      */
     public static boolean isCorrelationIDPresent() {
         return MDC.get(CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Resolve the user id of the given user object.
+     *
+     * @param user user object
+     * @return user-id
+     */
+    public static String resolveUserIdFromUser(User user) {
+        int tenantId = (user.getTenantDomain() == null) ? org.wso2.carbon.utils.multitenancy.MultitenantConstants
+                .INVALID_TENANT_ID : IdentityTenantUtil.getTenantId(user.getTenantDomain());
+        try {
+            return UserSessionStore.getInstance().getUserId(user.getUserName(), tenantId, user
+                    .getUserStoreDomain(), -1);
+        } catch (UserSessionException e) {
+            throw new APIError(Response.Status.BAD_REQUEST, new ErrorResponse.Builder()
+                    .withCode(ERROR_CODE_INVALID_USERNAME.getCode())
+                    .withMessage(ERROR_CODE_INVALID_USERNAME.getMessage())
+                    .withDescription(ERROR_CODE_INVALID_USERNAME.getDescription())
+                    .build(log, e, "Invalid userId: " + user.getUserName()));
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/error/ErrorResponse.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/error/ErrorResponse.java
@@ -77,6 +77,26 @@ public class ErrorResponse extends ErrorDTO {
             return error;
         }
 
+        /**
+         * Error response builder for bad requests without exceptions.
+         *
+         * @param log     Logger
+         * @param message Error message
+         * @return ErrorResponse object
+         */
+        public ErrorResponse build(Log log, String message) {
 
+            ErrorResponse error = build();
+            String errorMessageFormat = "errorCode: %s | message: %s";
+            String errorMsg = String.format(errorMessageFormat, error.getCode(), message);
+            if (!isCorrelationIDPresent()) {
+                errorMsg = String.format("correlationID: %s | " + errorMsg, error.getRef());
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug(errorMsg);
+            }
+            return error;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
@@ -35,6 +35,4 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.carbon.identity.user.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.user.session</artifactId>
+        <version>1.0.17-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.api.user.session.common</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.user.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.user.session</artifactId>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.user.session.common.constant;
+
+/**
+ * Contains all the session management related constants.
+ */
+public class SessionManagementConstants {
+
+    public static final String ERROR_CODE_DELIMITER = "-";
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+    public static final String USER_SESSION_MANAGEMENT_PREFIX = "USM";
+
+    /**
+     * Enum for user error messages
+     */
+    public enum ErrorMessage {
+        ERROR_CODE_PAGINATION_NOT_IMPLEMENTED("USM-00003",
+                "Pagination not supported.",
+                "Pagination capabilities are not supported in this version of the API."),
+        ERROR_CODE_FILTERING_NOT_IMPLEMENTED("USM-00004",
+                "Filtering not supported.",
+                "Filtering capability is not supported in this version of the API."),
+        ERROR_CODE_SORTING_NOT_IMPLEMENTED("USM-00005",
+                "Sorting not supported.",
+                "Sorting capability is not supported in this version of the API.")
+        ;
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public String toString() {
+            return code + " | " + message;
+        }
+
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
@@ -28,7 +28,7 @@ public class SessionManagementConstants {
     public static final String USER_SESSION_MANAGEMENT_PREFIX = "USM";
 
     /**
-     * Enum for user error messages
+     * Enum for user error messages.
      */
     public enum ErrorMessage {
         ERROR_CODE_PAGINATION_NOT_IMPLEMENTED("USM-00003",
@@ -68,7 +68,5 @@ public class SessionManagementConstants {
         public String toString() {
             return code + " | " + message;
         }
-
     }
-
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
@@ -24,48 +24,52 @@ package org.wso2.carbon.identity.api.user.session.common.constant;
 public class SessionManagementConstants {
 
     public static final String ERROR_CODE_DELIMITER = "-";
-    public static final String CORRELATION_ID_MDC = "Correlation-ID";
     public static final String USER_SESSION_MANAGEMENT_PREFIX = "USM";
 
     /**
      * Enum for user error messages.
      */
     public enum ErrorMessage {
-        ERROR_CODE_PAGINATION_NOT_IMPLEMENTED("USM-00003",
+
+        ERROR_CODE_PAGINATION_NOT_IMPLEMENTED("00003",
                 "Pagination not supported.",
                 "Pagination capabilities are not supported in this version of the API."),
-        ERROR_CODE_FILTERING_NOT_IMPLEMENTED("USM-00004",
+        ERROR_CODE_FILTERING_NOT_IMPLEMENTED("00004",
                 "Filtering not supported.",
                 "Filtering capability is not supported in this version of the API."),
-        ERROR_CODE_SORTING_NOT_IMPLEMENTED("USM-00005",
+        ERROR_CODE_SORTING_NOT_IMPLEMENTED("00005",
                 "Sorting not supported.",
-                "Sorting capability is not supported in this version of the API.")
-        ;
+                "Sorting capability is not supported in this version of the API.");
 
         private final String code;
         private final String message;
         private final String description;
 
         ErrorMessage(String code, String message, String description) {
+
             this.code = code;
             this.message = message;
             this.description = description;
         }
 
         public String getCode() {
-            return code;
+
+            return USER_SESSION_MANAGEMENT_PREFIX + ERROR_CODE_DELIMITER + code;
         }
 
         public String getMessage() {
+
             return message;
         }
 
         public String getDescription() {
+
             return description;
         }
 
         @Override
         public String toString() {
+
             return code + " | " + message;
         }
     }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
@@ -70,7 +70,7 @@ public class SessionManagementConstants {
         @Override
         public String toString() {
 
-            return code + " | " + message;
+            return getCode() + " | " + message;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/util/SessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/util/SessionManagementUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.user.session.common.util;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+
+/**
+ * Contains all session management related util methods.
+ */
+public class SessionManagementUtil {
+
+    /**
+     * Method to get the session management osgi service.
+     *
+     * @return UserSessionManagementService
+     */
+    public static UserSessionManagementService getUserSessionManagementService() {
+        return (UserSessionManagementService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getOSGiService(UserSessionManagementService.class, null);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
@@ -24,7 +24,7 @@
         <groupId>org.wso2.carbon.identity.user.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.user.session</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.rest.api.user.session.v1</artifactId>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
@@ -91,11 +91,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.user.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.user.session</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.0.17-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.rest.api.user.session.v1</artifactId>
+    <packaging>jar</packaging>
+    <name>WSO2 Identity Server - User Session Management Rest API</name>
+    <description>WSO2 Identity Server - User Session Management Rest API</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wso2.maven.plugins</groupId>
+                <artifactId>swagger2cxf-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <inputSpec>${project.basedir}/src/main/resources/session.yaml</inputSpec>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.user.common</artifactId>
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.user.session.common</artifactId>
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
@@ -42,14 +43,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.wso2.maven.plugins</groupId>
-                <artifactId>swagger2cxf-maven-plugin</artifactId>
-                <version>1.0-SNAPSHOT</version>
-                <configuration>
-                    <inputSpec>${project.basedir}/src/main/resources/session.yaml</inputSpec>
-                </configuration>
-            </plugin>
+            <!-- Dependency to generate the code from the swagger generation. -->
+            <!--<plugin>-->
+                <!--<groupId>org.wso2.maven.plugins</groupId>-->
+                <!--<artifactId>swagger2cxf-maven-plugin</artifactId>-->
+                <!--<version>1.0-SNAPSHOT</version>-->
+                <!--<configuration>-->
+                    <!--<inputSpec>${project.basedir}/src/main/resources/session.yaml</inputSpec>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -150,5 +152,4 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
@@ -1,0 +1,9 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+//comment
+public class ApiException extends Exception{
+	private int code;
+	public ApiException (int code, String msg) {
+		super(msg);
+		this.code = code;
+	}
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
 //comment

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiException.java
@@ -1,9 +1,12 @@
 package org.wso2.carbon.identity.rest.api.user.session.v1;
+
 //comment
-public class ApiException extends Exception{
-	private int code;
-	public ApiException (int code, String msg) {
-		super(msg);
-		this.code = code;
-	}
+public class ApiException extends Exception {
+
+    private int code;
+
+    public ApiException(int code, String msg) {
+        super(msg);
+        this.code = code;
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
@@ -4,65 +4,67 @@ import javax.xml.bind.annotation.XmlTransient;
 
 @javax.xml.bind.annotation.XmlRootElement
 public class ApiResponseMessage {
-	public static final int ERROR = 1;
-	public static final int WARNING = 2;
-	public static final int INFO = 3;
-	public static final int OK = 4;
-	public static final int TOO_BUSY = 5;
 
-	int code;
-	String type;
-	String message;
-	
-	public ApiResponseMessage(){}
-	
-	public ApiResponseMessage(int code, String message){
-		this.code = code;
-		switch(code){
-		case ERROR:
-			setType("error");
-			break;
-		case WARNING:
-			setType("warning");
-			break;
-		case INFO:
-			setType("info");
-			break;
-		case OK:
-			setType("ok");
-			break;
-		case TOO_BUSY:
-			setType("too busy");
-			break;
-		default:
-			setType("unknown");
-			break;
-		}
-		this.message = message;
-	}
+    public static final int ERROR = 1;
+    public static final int WARNING = 2;
+    public static final int INFO = 3;
+    public static final int OK = 4;
+    public static final int TOO_BUSY = 5;
 
-	@XmlTransient
-	public int getCode() {
-		return code;
-	}
+    int code;
+    String type;
+    String message;
 
-	public void setCode(int code) {
-		this.code = code;
-	}
+    public ApiResponseMessage() {
+    }
 
-	public String getType() {
-		return type;
-	}
+    public ApiResponseMessage(int code, String message) {
+        this.code = code;
+        switch (code) {
+            case ERROR:
+                setType("error");
+                break;
+            case WARNING:
+                setType("warning");
+                break;
+            case INFO:
+                setType("info");
+                break;
+            case OK:
+                setType("ok");
+                break;
+            case TOO_BUSY:
+                setType("too busy");
+                break;
+            default:
+                setType("unknown");
+                break;
+        }
+        this.message = message;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    @XmlTransient
+    public int getCode() {
+        return code;
+    }
 
-	public String getMessage() {
-		return message;
-	}
+    public void setCode(int code) {
+        this.code = code;
+    }
 
-	public void setMessage(String message) {
-		this.message = message;
-	}
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
@@ -1,0 +1,68 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+@javax.xml.bind.annotation.XmlRootElement
+public class ApiResponseMessage {
+	public static final int ERROR = 1;
+	public static final int WARNING = 2;
+	public static final int INFO = 3;
+	public static final int OK = 4;
+	public static final int TOO_BUSY = 5;
+
+	int code;
+	String type;
+	String message;
+	
+	public ApiResponseMessage(){}
+	
+	public ApiResponseMessage(int code, String message){
+		this.code = code;
+		switch(code){
+		case ERROR:
+			setType("error");
+			break;
+		case WARNING:
+			setType("warning");
+			break;
+		case INFO:
+			setType("info");
+			break;
+		case OK:
+			setType("ok");
+			break;
+		case TOO_BUSY:
+			setType("too busy");
+			break;
+		default:
+			setType("unknown");
+			break;
+		}
+		this.message = message;
+	}
+
+	@XmlTransient
+	public int getCode() {
+		return code;
+	}
+
+	public void setCode(int code) {
+		this.code = code;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/ApiResponseMessage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
 import javax.xml.bind.annotation.XmlTransient;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.*;
 import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.factories.MeApiServiceFactory;
@@ -24,7 +41,8 @@ import javax.ws.rs.*;
 @io.swagger.annotations.Api(value = "/me", description = "the me API")
 public class MeApi  {
 
-   private final MeApiService delegate = MeApiServiceFactory.getMeApi();
+   @Autowired
+   private MeApiService delegate;
 
     @GET
     @Path("/sessions")

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
@@ -1,0 +1,87 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.*;
+import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.factories.MeApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/me")
+
+
+@io.swagger.annotations.Api(value = "/me", description = "the me API")
+public class MeApi  {
+
+   private final MeApiService delegate = MeApiServiceFactory.getMeApi();
+
+    @GET
+    @Path("/sessions")
+    
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "get active sessions", notes = "Retrieve information related to the active sessions of the logged in user.", response = SessionsDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved session information"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "The specified resource is not found."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response getSessionsOfLoggedInUser(@ApiParam(value = "maximum number of records to return") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "number of records to skip for pagination") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Condition to filter the retrival of records.") @QueryParam("filter")  String filter,
+    @ApiParam(value = "Define the order how the retrieved records should be sorted.") @QueryParam("sort")  String sort)
+    {
+    return delegate.getSessionsOfLoggedInUser(limit,offset,filter,sort);
+    }
+    @DELETE
+    @Path("/sessions/{session-id}")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "Terminate a session", notes = "Terminate a given session of the logged in user", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid input request."),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response terminateSessionByLoggedInUser(@ApiParam(value = "id of the session",required=true ) @PathParam("session-id")  String sessionId)
+    {
+    return delegate.terminateSessionByLoggedInUser(sessionId);
+    }
+    @DELETE
+    @Path("/sessions")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "Terminate all sessions", notes = "Delete all the sessions of the logged in user", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid input request."),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response terminateSessionsByLoggedInUser()
+    {
+    return delegate.terminateSessionsByLoggedInUser();
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
 import org.wso2.carbon.identity.rest.api.user.session.v1.*;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
@@ -1,0 +1,21 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.*;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.*;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class MeApiService {
+    public abstract Response getSessionsOfLoggedInUser(Integer limit,Integer offset,String filter,String sort);
+    public abstract Response terminateSessionByLoggedInUser(String sessionId);
+    public abstract Response terminateSessionsByLoggedInUser();
+}
+

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,8 +41,8 @@ import javax.ws.rs.*;
 @io.swagger.annotations.Api(value = "/{user-id}", description = "the {user-id} API")
 public class UserIdApi  {
 
-    @Autowired
-    private UserIdApiService delegate;
+   @Autowired
+   private UserIdApiService delegate;
 
     @GET
     @Path("/sessions")

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
@@ -1,0 +1,93 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.*;
+import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.factories.UserIdApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/{user-id}")
+
+
+@io.swagger.annotations.Api(value = "/{user-id}", description = "the {user-id} API")
+public class UserIdApi  {
+
+    @Autowired
+    private UserIdApiService delegate;
+
+    @GET
+    @Path("/sessions")
+    
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "get active sessions", notes = "Retrieve information related to the active sessions of the user.", response = SessionsDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved session information"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid input request."),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "The specified resource is not found."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response getSessionsByUserId(@ApiParam(value = "id of the user",required=true ) @PathParam("user-id")  String userId,
+    @ApiParam(value = "maximum number of records to return") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "number of records to skip for pagination") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Condition to filter the retrival of records.") @QueryParam("filter")  String filter,
+    @ApiParam(value = "Define the order how the retrieved records should be sorted.") @QueryParam("sort")  String sort)
+    {
+    return delegate.getSessionsByUserId(userId,limit,offset,filter,sort);
+    }
+    @DELETE
+    @Path("/sessions/{session-id}")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "Terminate a session", notes = "Terminate a given session of a given user", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid input request."),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response terminateSessionBySessionId(@ApiParam(value = "id of the user",required=true ) @PathParam("user-id")  String userId,
+    @ApiParam(value = "id of the session",required=true ) @PathParam("session-id")  String sessionId)
+    {
+    return delegate.terminateSessionBySessionId(userId,sessionId);
+    }
+    @DELETE
+    @Path("/sessions")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "Terminate all sessions", notes = "Delete all the sessions of the given in user", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid input request."),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized."),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
+
+    public Response terminateSessionsByUserId(@ApiParam(value = "id of the user",required=true ) @PathParam("user-id")  String userId)
+    {
+    return delegate.terminateSessionsByUserId(userId);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
@@ -1,0 +1,21 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.*;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.*;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class UserIdApiService {
+    public abstract Response getSessionsByUserId(String userId,Integer limit,Integer offset,String filter,String sort);
+    public abstract Response terminateSessionBySessionId(String userId,String sessionId);
+    public abstract Response terminateSessionsByUserId(String userId);
+}
+

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1;
 
 import org.wso2.carbon.identity.rest.api.user.session.v1.*;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -1,0 +1,78 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ApplicationDTO  {
+  
+  
+  @NotNull
+  private String subject = null;
+  
+  @NotNull
+  private String appName = null;
+  
+  @NotNull
+  private String appId = null;
+
+  
+  /**
+   * Username for the application
+   **/
+  @ApiModelProperty(required = true, value = "Username for the application")
+  @JsonProperty("subject")
+  public String getSubject() {
+    return subject;
+  }
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  
+  /**
+   * Name of the application
+   **/
+  @ApiModelProperty(required = true, value = "Name of the application")
+  @JsonProperty("appName")
+  public String getAppName() {
+    return appName;
+  }
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
+
+  
+  /**
+   * ID of the application
+   **/
+  @ApiModelProperty(required = true, value = "ID of the application")
+  @JsonProperty("appId")
+  public String getAppId() {
+    return appId;
+  }
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ApplicationDTO {\n");
+    
+    sb.append("  subject: ").append(subject).append("\n");
+    sb.append("  appName: ").append(appName).append("\n");
+    sb.append("  appId: ").append(appId).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
 
@@ -5,6 +21,7 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 
 
@@ -14,13 +31,13 @@ import javax.validation.constraints.NotNull;
 public class ApplicationDTO  {
   
   
-  @NotNull
+  @NotNull 
   private String subject = null;
   
-  @NotNull
+  @NotNull 
   private String appName = null;
   
-  @NotNull
+  @NotNull 
   private String appId = null;
 
   

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
 
@@ -5,6 +21,7 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 
 
@@ -14,10 +31,10 @@ import javax.validation.constraints.NotNull;
 public class ErrorDTO  {
   
   
-  @NotNull
+  @NotNull 
   private String code = null;
   
-  @NotNull
+  @NotNull 
   private String message = null;
   
   

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
@@ -1,0 +1,91 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ErrorDTO  {
+  
+  
+  @NotNull
+  private String code = null;
+  
+  @NotNull
+  private String message = null;
+  
+  
+  private String description = null;
+  
+  
+  private String traceId = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("code")
+  public String getCode() {
+    return code;
+  }
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getTraceId() {
+    return traceId;
+  }
+  public void setTraceId(String traceId) {
+    this.traceId = traceId;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ErrorDTO {\n");
+    
+    sb.append("  code: ").append(code).append("\n");
+    sb.append("  message: ").append(message).append("\n");
+    sb.append("  description: ").append(description).append("\n");
+    sb.append("  traceId: ").append(traceId).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
 import java.util.ArrayList;
@@ -8,6 +24,7 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 
 

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
@@ -1,0 +1,132 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ApplicationDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SessionDTO  {
+  
+  
+  
+  private List<ApplicationDTO> applications = new ArrayList<ApplicationDTO>();
+  
+  
+  private String userAgent = null;
+  
+  
+  private String ip = null;
+  
+  
+  private String loginTime = null;
+  
+  
+  private String lastAccessTime = null;
+  
+  
+  private String id = null;
+
+  
+  /**
+   * List of active applications in the session
+   **/
+  @ApiModelProperty(value = "List of active applications in the session")
+  @JsonProperty("applications")
+  public List<ApplicationDTO> getApplications() {
+    return applications;
+  }
+  public void setApplications(List<ApplicationDTO> applications) {
+    this.applications = applications;
+  }
+
+  
+  /**
+   * User agent of the session
+   **/
+  @ApiModelProperty(value = "User agent of the session")
+  @JsonProperty("userAgent")
+  public String getUserAgent() {
+    return userAgent;
+  }
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  
+  /**
+   * IP address of the session
+   **/
+  @ApiModelProperty(value = "IP address of the session")
+  @JsonProperty("ip")
+  public String getIp() {
+    return ip;
+  }
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  
+  /**
+   * Login time of the session
+   **/
+  @ApiModelProperty(value = "Login time of the session")
+  @JsonProperty("loginTime")
+  public String getLoginTime() {
+    return loginTime;
+  }
+  public void setLoginTime(String loginTime) {
+    this.loginTime = loginTime;
+  }
+
+  
+  /**
+   * Last access time of the session
+   **/
+  @ApiModelProperty(value = "Last access time of the session")
+  @JsonProperty("lastAccessTime")
+  public String getLastAccessTime() {
+    return lastAccessTime;
+  }
+  public void setLastAccessTime(String lastAccessTime) {
+    this.lastAccessTime = lastAccessTime;
+  }
+
+  
+  /**
+   * ID of the session
+   **/
+  @ApiModelProperty(value = "ID of the session")
+  @JsonProperty("id")
+  public String getId() {
+    return id;
+  }
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SessionDTO {\n");
+    
+    sb.append("  applications: ").append(applications).append("\n");
+    sb.append("  userAgent: ").append(userAgent).append("\n");
+    sb.append("  ip: ").append(ip).append("\n");
+    sb.append("  loginTime: ").append(loginTime).append("\n");
+    sb.append("  lastAccessTime: ").append(lastAccessTime).append("\n");
+    sb.append("  id: ").append(id).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
@@ -1,17 +1,19 @@
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
@@ -1,0 +1,63 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SessionsDTO  {
+  
+  
+  @NotNull
+  private String userId = null;
+  
+  
+  private List<SessionDTO> sessions = new ArrayList<SessionDTO>();
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("userId")
+  public String getUserId() {
+    return userId;
+  }
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  
+  /**
+   * List of active sessions
+   **/
+  @ApiModelProperty(value = "List of active sessions")
+  @JsonProperty("sessions")
+  public List<SessionDTO> getSessions() {
+    return sessions;
+  }
+  public void setSessions(List<SessionDTO> sessions) {
+    this.sessions = sessions;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SessionsDTO {\n");
+    
+    sb.append("  userId: ").append(userId).append("\n");
+    sb.append("  sessions: ").append(sessions).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
 import java.util.ArrayList;
@@ -8,6 +24,7 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 
 
@@ -17,7 +34,7 @@ import javax.validation.constraints.NotNull;
 public class SessionsDTO  {
   
   
-  @NotNull
+  @NotNull 
   private String userId = null;
   
   

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/MeApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/MeApiServiceFactory.java
@@ -1,0 +1,13 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.factories;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.impl.MeApiServiceImpl;
+
+public class MeApiServiceFactory {
+
+    private final static MeApiService service = new MeApiServiceImpl();
+
+    public static MeApiService getMeApi() {
+        return service;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/MeApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/MeApiServiceFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.factories;
 
 import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/UserIdApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/UserIdApiServiceFactory.java
@@ -1,0 +1,13 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.factories;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.impl.UserIdApiServiceImpl;
+
+public class UserIdApiServiceFactory {
+
+    private final static UserIdApiService service = new UserIdApiServiceImpl();
+
+    public static UserIdApiService getUserIdApi() {
+        return service;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/UserIdApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/factories/UserIdApiServiceFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.factories;
 
 import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -160,9 +160,9 @@ public class SessionManagementService {
 
         SessionManagementConstants.ErrorMessage errorEnum = null;
 
-        if (limit != null && limit != 0) {
+        if (limit != null) {
             errorEnum = ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
-        } else if (offset != null && offset != 0) {
+        } else if (offset != null) {
             errorEnum = ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
         } else if (filter != null) {
             errorEnum = ERROR_CODE_FILTERING_NOT_IMPLEMENTED;

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.UserS
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.function.UserSessionToExternal;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,20 +46,26 @@ import static org.wso2.carbon.identity.api.user.session.common.constant.SessionM
 import static org.wso2.carbon.identity.api.user.session.common.constant.SessionManagementConstants.ErrorMessage
         .ERROR_CODE_SORTING_NOT_IMPLEMENTED;
 
+/**
+ * Call internal osgi services to perform user session related operations
+ */
 public class SessionManagementService {
 
     private static final Log log = LogFactory.getLog(SessionManagementService.class);
 
-    public List<SessionDTO> getSessionsBySessionId(User user, Integer limit, Integer offset, String filter, String
+    public SessionsDTO getSessionsBySessionId(User user, Integer limit, Integer offset, String filter, String
             sort) {
 
         handleNotImplementedCapabilities(limit, offset, filter, sort);
 
         List<UserSession> sessionsForUser;
+        SessionsDTO sessions = new SessionsDTO();
         try {
             String userId = resolveUserIdFromUser(user);
             sessionsForUser = SessionManagementUtil.getUserSessionManagementService().getSessionsByUserId(userId);
-            return buildSessionDTOs(sessionsForUser);
+            sessions.setUserId(userId);
+            sessions.setSessions(buildSessionDTOs(sessionsForUser));
+            return sessions;
 
         } catch (SessionManagementException e) {
             log.error(e.getMessage());

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.user.session.v1.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.user.common.error.APIError;
+import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.user.session.common.constant.SessionManagementConstants;
+import org.wso2.carbon.identity.api.user.session.common.util.SessionManagementUtil;
+import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt
+        .SessionManagementClientException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
+import org.wso2.carbon.identity.application.authentication.framework.model.UserSession;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.rest.api.user.session.v1.core.function.UserSessionToExternal;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.user.common.Constants.ERROR_CODE_DELIMITER;
+import static org.wso2.carbon.identity.api.user.common.Util.resolveUserIdFromUser;
+import static org.wso2.carbon.identity.api.user.session.common.constant.SessionManagementConstants.ErrorMessage
+        .ERROR_CODE_FILTERING_NOT_IMPLEMENTED;
+import static org.wso2.carbon.identity.api.user.session.common.constant.SessionManagementConstants.ErrorMessage
+        .ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
+import static org.wso2.carbon.identity.api.user.session.common.constant.SessionManagementConstants.ErrorMessage
+        .ERROR_CODE_SORTING_NOT_IMPLEMENTED;
+
+public class SessionManagementService {
+
+    private static final Log log = LogFactory.getLog(SessionManagementService.class);
+
+    public List<SessionDTO> getSessionsBySessionId(User user, Integer limit, Integer offset, String filter, String
+            sort) {
+
+        handleNotImplementedCapabilities(limit, offset, filter, sort);
+
+        List<UserSession> sessionsForUser;
+        try {
+            String userId = resolveUserIdFromUser(user);
+            sessionsForUser = SessionManagementUtil.getUserSessionManagementService().getSessionsByUserId(userId);
+            return buildSessionDTOs(sessionsForUser);
+
+        } catch (SessionManagementException e) {
+            log.error(e.getMessage());
+            handleSessionManagementException(e);
+            return null;
+        }
+
+    }
+
+    public void terminateSessionBySessionId(User user, String sessionId) {
+
+        String userId = resolveUserIdFromUser(user);
+        SessionManagementUtil.getUserSessionManagementService().terminateSessionBySessionId(userId, sessionId);
+
+    }
+
+    public void terminateSessionsByUserId(User user) {
+        try {
+            String userId = resolveUserIdFromUser(user);
+            SessionManagementUtil.getUserSessionManagementService().terminateSessionsByUserId(userId);
+        } catch (SessionManagementException e) {
+            handleSessionManagementException(e);
+        }
+    }
+
+    private List<SessionDTO> buildSessionDTOs(List<UserSession> userSessionList) {
+
+        return userSessionList.stream().map(new UserSessionToExternal()).collect(Collectors.toList());
+    }
+
+    private void handleSessionManagementException(SessionManagementException e) {
+
+        ErrorResponse errorResponse = getErrorBuilder(e).build(log, e, e.getDescription());
+
+        if (e.getErrorCode() != null) {
+            String errorCode = e.getErrorCode();
+            errorCode = errorCode.contains(ERROR_CODE_DELIMITER) ? errorCode : SessionManagementConstants
+                    .USER_SESSION_MANAGEMENT_PREFIX + SessionManagementConstants.ERROR_CODE_DELIMITER + errorCode;
+            errorResponse.setCode(errorCode);
+        }
+
+        Response.Status status;
+
+        if (e instanceof SessionManagementClientException) {
+            errorResponse.setDescription(e.getMessage());
+            status = Response.Status.BAD_REQUEST;
+        } else {
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+
+        throw new APIError(status, errorResponse);
+    }
+
+    private ErrorResponse.Builder getErrorBuilder(SessionManagementException error) {
+
+        return new ErrorResponse.Builder()
+                .withCode(error.getErrorCode())
+                .withMessage(error.getMessage())
+                .withDescription(error.getDescription());
+    }
+
+    private ErrorResponse.Builder getErrorBuilder(SessionManagementConstants.ErrorMessage error) {
+
+        return new ErrorResponse.Builder()
+                .withCode(error.getCode())
+                .withMessage(error.getMessage())
+                .withDescription(error.getDescription());
+    }
+
+    private void handleNotImplementedCapabilities(Integer limit, Integer offset, String filter, String sort) {
+
+        SessionManagementConstants.ErrorMessage errorEnum = null;
+
+        if (limit != null && limit != 0) {
+            errorEnum = ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
+        } else if (offset != null && offset != 0) {
+            errorEnum = ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
+        } else if (filter != null) {
+            errorEnum = ERROR_CODE_FILTERING_NOT_IMPLEMENTED;
+        } else if (sort != null) {
+            errorEnum = ERROR_CODE_SORTING_NOT_IMPLEMENTED;
+        }
+
+        if (errorEnum != null) {
+            ErrorResponse errorResponse = getErrorBuilder(errorEnum).build(log, errorEnum.getDescription());
+            Response.Status status = Response.Status.NOT_IMPLEMENTED;
+
+            throw new APIError(status, errorResponse);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -47,12 +47,22 @@ import static org.wso2.carbon.identity.api.user.session.common.constant.SessionM
         .ERROR_CODE_SORTING_NOT_IMPLEMENTED;
 
 /**
- * Call internal osgi services to perform user session related operations
+ * Call internal osgi services to perform user session related operations.
  */
 public class SessionManagementService {
 
     private static final Log log = LogFactory.getLog(SessionManagementService.class);
 
+    /**
+     * Get all the active sessions of a given user.
+     *
+     * @param user   user
+     * @param limit  limit (optional)
+     * @param offset offset (optional)
+     * @param filter filter (optional)
+     * @param sort   sort (optional)
+     * @return SessionsDTO
+     */
     public SessionsDTO getSessionsBySessionId(User user, Integer limit, Integer offset, String filter, String
             sort) {
 
@@ -72,9 +82,14 @@ public class SessionManagementService {
             handleSessionManagementException(e);
             return null;
         }
-
     }
 
+    /**
+     * Terminate the session of the given session id.
+     *
+     * @param user      user
+     * @param sessionId session id
+     */
     public void terminateSessionBySessionId(User user, String sessionId) {
 
         String userId = resolveUserIdFromUser(user);
@@ -82,7 +97,13 @@ public class SessionManagementService {
 
     }
 
+    /**
+     * Terminate all the sessions of the given user.
+     *
+     * @param user      user
+     */
     public void terminateSessionsByUserId(User user) {
+
         try {
             String userId = resolveUserIdFromUser(user);
             SessionManagementUtil.getUserSessionManagementService().terminateSessionsByUserId(userId);

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -78,9 +78,7 @@ public class SessionManagementService {
             return sessions;
 
         } catch (SessionManagementException e) {
-            log.error(e.getMessage());
-            handleSessionManagementException(e);
-            return null;
+            throw handleSessionManagementException(e);
         }
     }
 
@@ -108,7 +106,7 @@ public class SessionManagementService {
             String userId = resolveUserIdFromUser(user);
             SessionManagementUtil.getUserSessionManagementService().terminateSessionsByUserId(userId);
         } catch (SessionManagementException e) {
-            handleSessionManagementException(e);
+            throw handleSessionManagementException(e);
         }
     }
 
@@ -117,7 +115,7 @@ public class SessionManagementService {
         return userSessionList.stream().map(new UserSessionToExternal()).collect(Collectors.toList());
     }
 
-    private void handleSessionManagementException(SessionManagementException e) {
+    private APIError handleSessionManagementException(SessionManagementException e) {
 
         ErrorResponse errorResponse = getErrorBuilder(e).build(log, e, e.getDescription());
 
@@ -137,7 +135,7 @@ public class SessionManagementService {
             status = Response.Status.INTERNAL_SERVER_ERROR;
         }
 
-        throw new APIError(status, errorResponse);
+        return new APIError(status, errorResponse);
     }
 
     private ErrorResponse.Builder getErrorBuilder(SessionManagementException error) {

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.user.session.v1.core.function;
+
+import org.wso2.carbon.identity.application.authentication.framework.model.Application;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ApplicationDTO;
+
+import java.util.function.Function;
+
+public class ApplicationToExternal implements Function<Application, ApplicationDTO> {
+
+    @Override
+    public ApplicationDTO apply(Application application) {
+
+        ApplicationDTO applicationDTO = new ApplicationDTO();
+        applicationDTO.setAppId(application.getAppId());
+        applicationDTO.setSubject(application.getSubject());
+        applicationDTO.setAppName(application.getAppName());
+
+        return applicationDTO;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
@@ -23,6 +23,9 @@ import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ApplicationDTO;
 
 import java.util.function.Function;
 
+/**
+ * Transform internal Application object to external ApplicationDTO.
+ */
 public class ApplicationToExternal implements Function<Application, ApplicationDTO> {
 
     @Override
@@ -35,5 +38,4 @@ public class ApplicationToExternal implements Function<Application, ApplicationD
 
         return applicationDTO;
     }
-
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/UserSessionToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/UserSessionToExternal.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.user.session.v1.core.function;
+
+import org.wso2.carbon.identity.application.authentication.framework.model.UserSession;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ApplicationDTO;
+import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class UserSessionToExternal implements Function<UserSession, SessionDTO> {
+
+    @Override
+    public SessionDTO apply(UserSession userSession) {
+
+        List<ApplicationDTO> appDTOs = userSession.getApplications().stream().map(new ApplicationToExternal())
+                .collect(Collectors.toList());
+
+        SessionDTO session = new SessionDTO();
+        session.setApplications(appDTOs);
+        session.setIp(userSession.getIp());
+        session.setLastAccessTime(userSession.getLastAccessTime());
+        session.setLoginTime(userSession.getLoginTime());
+        session.setUserAgent(userSession.getUserAgent());
+        session.setId(userSession.getSessionId());
+
+        return session;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/UserSessionToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/UserSessionToExternal.java
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Transform internal user session object to external SessionDTO.
+ */
 public class UserSessionToExternal implements Function<UserSession, SessionDTO> {
 
     @Override
@@ -44,5 +47,4 @@ public class UserSessionToExternal implements Function<UserSession, SessionDTO> 
 
         return session;
     }
-
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
@@ -1,0 +1,27 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
+
+import org.wso2.carbon.identity.rest.api.user.session.v1.ApiResponseMessage;
+import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
+
+import javax.ws.rs.core.Response;
+
+public class MeApiServiceImpl extends MeApiService {
+
+    @Override
+    public Response getSessionsOfLoggedInUser() {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+
+    @Override
+    public Response terminateSessionByLoggedInUser(String sessionId) {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+
+    @Override
+    public Response terminateSessionsByLoggedInUser() {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
@@ -1,17 +1,34 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
-import org.wso2.carbon.identity.api.user.common.function.UserIdToUser;
-import org.wso2.carbon.identity.rest.api.user.session.v1.ApiResponseMessage;
 import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.user.common.ContextLoader.getUserFromContext;
-import static org.wso2.carbon.identity.api.user.common.ContextLoader.getUsernameFromContext;
 
+/**
+ * API service implementation of the authenticated user's session related operations.
+ */
 public class MeApiServiceImpl extends MeApiService {
 
     @Autowired

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
@@ -1,27 +1,42 @@
 package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.user.common.ContextLoader;
+import org.wso2.carbon.identity.api.user.common.function.UserIdToUser;
 import org.wso2.carbon.identity.rest.api.user.session.v1.ApiResponseMessage;
 import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 
 import javax.ws.rs.core.Response;
 
+import static org.wso2.carbon.identity.api.user.common.ContextLoader.getUserFromContext;
+import static org.wso2.carbon.identity.api.user.common.ContextLoader.getUsernameFromContext;
+
 public class MeApiServiceImpl extends MeApiService {
 
+    @Autowired
+    private SessionManagementService sessionManagementService;
+
     @Override
-    public Response getSessionsOfLoggedInUser() {
-        // do some magic!
-        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    public Response getSessionsOfLoggedInUser(Integer limit, Integer offset, String filter, String sort) {
+
+        return Response.ok().entity(sessionManagementService.getSessionsBySessionId(getUserFromContext(), limit,
+                offset, filter, sort)).build();
     }
 
     @Override
     public Response terminateSessionByLoggedInUser(String sessionId) {
-        // do some magic!
-        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+
+        sessionManagementService.terminateSessionBySessionId(getUserFromContext(), sessionId);
+
+        return Response.noContent().build();
     }
 
     @Override
     public Response terminateSessionsByLoggedInUser() {
-        // do some magic!
-        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+
+        sessionManagementService.terminateSessionsByUserId(getUserFromContext());
+
+        return Response.noContent().build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
@@ -1,0 +1,40 @@
+package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.user.common.ContextLoader;
+import org.wso2.carbon.identity.api.user.common.function.UserIdToUser;
+import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;
+import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
+
+import javax.ws.rs.core.Response;
+
+public class UserIdApiServiceImpl extends UserIdApiService {
+
+    @Autowired
+    private SessionManagementService sessionManagementService;
+
+    @Override
+    public Response getSessionsByUserId(String userId, Integer limit, Integer offset, String filter, String sort) {
+        return Response.ok().entity(sessionManagementService.getSessionsBySessionId(
+                new UserIdToUser().apply(userId, ContextLoader.getTenantDomainFromContext()), limit, offset, filter,
+                sort)).build();
+    }
+
+    @Override
+    public Response terminateSessionBySessionId(String userId, String sessionId) {
+
+        sessionManagementService.terminateSessionBySessionId(new UserIdToUser().apply(userId, ContextLoader
+                .getTenantDomainFromContext()), sessionId);
+
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response terminateSessionsByUserId(String userId) {
+
+        sessionManagementService.terminateSessionsByUserId(new UserIdToUser().apply(userId, ContextLoader
+                .getTenantDomainFromContext()));
+
+        return Response.noContent().build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
@@ -15,6 +15,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
 
     @Override
     public Response getSessionsByUserId(String userId, Integer limit, Integer offset, String filter, String sort) {
+
         return Response.ok().entity(sessionManagementService.getSessionsBySessionId(
                 new UserIdToUser().apply(userId, ContextLoader.getTenantDomainFromContext()), limit, offset, filter,
                 sort)).build();

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +26,9 @@ import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementS
 
 import javax.ws.rs.core.Response;
 
+/**
+ * API service implementation of a specific user's session related operations.
+ */
 public class UserIdApiServiceImpl extends UserIdApiService {
 
     @Autowired

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/META-INF/cxf/session-user-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/META-INF/cxf/session-user-v1-cxf.xml
@@ -21,4 +21,5 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
     <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService"/>
     <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.impl.UserIdApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.impl.MeApiServiceImpl"/>
 </beans>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/META-INF/cxf/session-user-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/META-INF/cxf/session-user-v1-cxf.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService"/>
+    <bean class="org.wso2.carbon.identity.rest.api.user.session.v1.impl.UserIdApiServiceImpl"/>
+</beans>

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -13,8 +13,8 @@ info:
 
 schemes:
  - https
-# host: is.wso2.com
-# basePath: /t/{tenant-domain}/api/identity/1.0.0/
+host: localhost:9443
+basePath: /api/users/v1
 
 # tags are used for organizing operations
 tags:

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -1,0 +1,340 @@
+swagger: '2.0'
+info:
+  description: This is the RESTful API for managing Sessions in WSO2 Identity Server
+  version: '1.0.0'
+  title: WSO2 Identity Server - Session Management API
+  contact:
+    name: 'WSO2 Identity Server'
+    url: 'https://wso2.com/identity-and-access-management/'
+    email: 'architecture@wso2.com'
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+schemes:
+ - https
+# host: is.wso2.com
+# basePath: /t/{tenant-domain}/api/identity/1.0.0/
+
+# tags are used for organizing operations
+tags:
+- name: management
+  description: Secured Admin-only calls
+- name: developers
+  description: Operations available to regular developers
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  /{user-id}/sessions:
+    get:
+      tags:
+        - management
+      description: Retrieve information related to the active sessions of the user.
+      summary: get active sessions
+      operationId: getSessionsByUserId
+      parameters:
+        - $ref: '#/parameters/userIdPathParam'
+        - $ref: '#/parameters/limitQueryParam'
+        - $ref: '#/parameters/offsetQueryParam'
+        - $ref: '#/parameters/filterQueryParam'
+        - $ref: '#/parameters/sortQueryParam'
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successfully retrieved session information
+          schema:
+            $ref: '#/definitions/Sessions'
+        400:
+            $ref: '#/responses/InvalidInput'
+        401:
+            $ref: '#/responses/Unauthorized'
+        404:
+            $ref: '#/responses/NotFound'
+        500:
+            $ref: '#/responses/ServerError'
+    delete:
+      tags:
+        - management
+      description: Delete all the sessions of the given in user
+      summary: Terminate all sessions
+      operationId: terminateSessionsByUserId
+      parameters:
+        - $ref: '#/parameters/userIdPathParam'
+      responses:
+        204:
+          $ref: '#/responses/NoContent'
+        400:
+          $ref: '#/responses/InvalidInput'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/ServerError'
+
+  /me/sessions:
+    get:
+      tags:
+        - developers
+      description: Retrieve information related to the active sessions of the logged in user.
+      summary: get active sessions
+      operationId: getSessionsOfLoggedInUser
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/limitQueryParam'
+        - $ref: '#/parameters/offsetQueryParam'
+        - $ref: '#/parameters/filterQueryParam'
+        - $ref: '#/parameters/sortQueryParam'
+      responses:
+        200:
+          description: Successfully retrieved session information
+          schema:
+            $ref: '#/definitions/Sessions'
+        401:
+            $ref: '#/responses/Unauthorized'
+        404:
+            $ref: '#/responses/NotFound'
+        500:
+            $ref: '#/responses/ServerError'
+
+    delete:
+      tags:
+        - developers
+      description: Delete all the sessions of the logged in user
+      summary: Terminate all sessions
+      operationId: terminateSessionsByLoggedInUser
+      responses:
+        204:
+          $ref: '#/responses/NoContent'
+        400:
+          $ref: '#/responses/InvalidInput'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/ServerError'
+
+  /{user-id}/sessions/{session-id}:
+    delete:
+      tags:
+        - management
+      description: Terminate a given session of a given user
+      summary: Terminate a session
+      operationId: terminateSessionBySessionId
+      parameters:
+        - $ref: '#/parameters/userIdPathParam'
+        - $ref: '#/parameters/sessionIdPathParam'
+      responses:
+        204:
+          $ref: '#/responses/NoContent'
+        400:
+          $ref: '#/responses/InvalidInput'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/ServerError'
+
+  /me/sessions/{session-id}:
+    delete:
+      tags:
+        - developers
+      description: Terminate a given session of the logged in user
+      summary: Terminate a session
+      operationId: terminateSessionByLoggedInUser
+      parameters:
+        - $ref: '#/parameters/sessionIdPathParam'
+      responses:
+        204:
+          $ref: '#/responses/NoContent'
+        400:
+          $ref: '#/responses/InvalidInput'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/ServerError'
+
+#-----------------------------------------------------
+# Descriptions of common responses
+#-----------------------------------------------------
+responses:
+  NotFound:
+    description: The specified resource is not found.
+    schema:
+      $ref: '#/definitions/Error'
+  Unauthorized:
+    description: Unauthorized.
+    schema:
+      $ref: '#/definitions/Error'
+  ServerError:
+    description: Internal Server Error.
+    schema:
+      $ref: '#/definitions/Error'
+  NotImplemented:
+    description: Not Implemented.
+    schema:
+      $ref: '#/definitions/Error'
+  InvalidInput:
+    description: Invalid input request.
+    schema:
+      $ref: '#/definitions/Error'
+  OK:
+    description: OK.
+  NoContent:
+    description: No Content.
+
+definitions:
+  #-----------------------------------------------------
+  # The Application Response object
+  #-----------------------------------------------------
+  Application:
+    type: object
+    required:
+      - subject
+      - appName
+      - appId
+    properties:
+      subject:
+        type: string
+        description: Username for the application
+        example: apiuser01
+      appName:
+        type: string
+        description: Name of the application
+        example: sampleApp
+      appId:
+        type: string
+        description: ID of the application
+        example: '012'
+
+  #-----------------------------------------------------
+  # The Session Response  object
+  #-----------------------------------------------------
+  Session:
+    type: object
+    properties:
+      applications:
+        type: array
+        description: List of active applications in the session
+        items:
+          $ref: '#/definitions/Application'
+      userAgent:
+        type: string
+        description: User agent of the session
+        example: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1'
+      ip:
+        type: string
+        description: IP address of the session
+        example: '172.95.192.63'
+      loginTime:
+        type: string
+        description: Login time of the session
+        example: '1560412617'
+      lastAccessTime:
+        type: string
+        description: Last access time of the session
+        example: '1560416196'
+      id:
+        type: string
+        description: ID of the session
+        example: '8d9806d1-4efc-483e-a96a-a0fa77d4328b'
+
+  #-----------------------------------------------------
+  # The Sessions Response  object
+  #-----------------------------------------------------
+  Sessions:
+    type: object
+    required:
+      - userId
+    properties:
+      userId:
+        type: string
+        example: '00000001'
+      sessions:
+        type: array
+        description: List of active sessions
+        items:
+          $ref: '#/definitions/Session'
+
+  #-----------------------------------------------------
+  # Error  object
+  #-----------------------------------------------------
+  Error:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: string
+        example: "AAA-00000"
+      message:
+        type: string
+        example: "Some Error Message"
+      description:
+        type: string
+        example: "Some Error Description"
+      traceId:
+        type: string
+        example: "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047"
+
+#--------------------
+# Parameters
+#--------------------
+parameters:
+    limitQueryParam:
+      in: query
+      name: limit
+      required: false
+      description: maximum number of records to return
+      type: integer
+      format: int32
+    offsetQueryParam:
+      in: query
+      name: offset
+      required: false
+      description: number of records to skip for pagination
+      type: integer
+      format: int32
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description: Condition to filter the retrival of records.
+      type: string
+    sortQueryParam:
+      in: query
+      name: sort
+      required: false
+      description: Define the order how the retrieved records should be sorted.
+      type: string
+    userIdPathParam:
+      in: path
+      name: user-id
+      description: id of the user
+      required: true
+      type: string
+    sessionIdPathParam:
+      in: path
+      name: session-id
+      description: id of the session
+      required: true
+      type: string
+
+#---------------------
+# Security Definitions
+#---------------------
+securityDefinitions:
+  BasicAuth:
+    type: basic
+  # ClientCertificate:
+  #   type: custom
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://localhost:9443/oauth/authorize
+    tokenUrl: https://localhost:9443/oauth/token
+    scopes:
+      read: Grants read access
+      write: Grants write access
+      admin: Grants read and write access to administrative information

--- a/components/org.wso2.carbon.identity.api.user.session/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-api-user</artifactId>
+        <groupId>org.wso2.carbon.identity.user.api</groupId>
+        <version>1.0.17-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.api.user.session</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>org.wso2.carbon.identity.api.user.session.common</module>
+        <module>org.wso2.carbon.identity.api.user.session.v1</module>
+    </modules>
+
+</project>

--- a/components/org.wso2.carbon.identity.api.user.session/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>identity-api-user</artifactId>
         <groupId>org.wso2.carbon.identity.user.api</groupId>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.api.user.session/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.session/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.2.6</identity.governance.version>
-        <carbon.identity.framework.version>5.13.52</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.13.53</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.2.3</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,12 @@
                 <version>${carbon.business-process.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -332,7 +338,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.2.6</identity.governance.version>
-        <carbon.identity.framework.version>5.13.8</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.13.49</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.2.3</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>
@@ -345,6 +351,7 @@
         <module>components/org.wso2.carbon.identity.api.user.challenge</module>
         <module>components/org.wso2.carbon.identity.api.user.authorized.apps</module>
         <module>components/org.wso2.carbon.identity.api.user.approval</module>
+        <module>components/org.wso2.carbon.identity.api.user.session</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.2.6</identity.governance.version>
-        <carbon.identity.framework.version>5.13.49</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.13.52</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.2.3</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>
@@ -355,8 +355,4 @@
     </modules>
 
 </project>
-
-
-
-
 


### PR DESCRIPTION
## Purpose
This PR will add the session management APIs

- GET  /{user-id}/sessions
- DELETE /{user-id}/sessions
- DELETE /{user-id}/sessions/{session-id}
- GET /me/sessions
- DELETE /me/sessions
- DELETE /me/sessions/{session-id}

## Approach
Uses the backend functionalities introduced by https://github.com/wso2/carbon-identity-framework/pull/2288
