### PR TITLE
Use username when creating the associations instead of using userId.

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
@@ -2,9 +2,6 @@ package org.wso2.carbon.identity.rest.api.user.association.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
-import org.wso2.carbon.identity.api.user.common.function.UserIdToUser;
-import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.rest.api.user.association.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.dto.AssociationSwitchRequestDTO;
@@ -43,7 +40,6 @@ public class MeApiServiceImpl extends MeApiService {
     @Override
     public Response meAssociationsPost(AssociationUserRequestDTO association) {
 
-        association.setUserId(getUser(association.getUserId()));
         userAssociationService.createUserAccountAssociation(association);
         return Response.created(getAssociationsLocationURI()).build();
     }
@@ -64,10 +60,5 @@ public class MeApiServiceImpl extends MeApiService {
     private URI getAssociationsLocationURI() {
 
         return buildURI(String.format(V1_API_PATH_COMPONENT + USER_ASSOCIATIONS_PATH_COMPONENT, ME_CONTEXT));
-    }
-
-    private String getUser(String userId) {
-        User user = new UserIdToUser().apply(userId, ContextLoader.getTenantDomainFromContext());
-        return user.toFullQualifiedUsername();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/UserIdApiServiceImpl.java
@@ -39,7 +39,6 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     @Override
     public Response userIdAssociationsPost(AssociationRequestDTO association, String userId) {
 
-        association.setAssociateUserId(getUser(association.getAssociateUserId()));
         userAssociationService.createUserAccountAssociation(association, getUser(userId));
         return Response.created(getAssociationsLocationURI(userId)).build();
     }

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
@@ -52,7 +52,7 @@ consumes:
 produces:
   - application/json
 paths:
-  # Endpoint uses to assiate two user accounts.
+  # Endpoint uses to associate two user accounts.
   /me/associations:
     post:
       description: |
@@ -151,6 +151,10 @@ paths:
           description: Unauthorized
         500:
           description: Server Error
+          schema:
+             $ref: '#/definitions/Error'
+        501:
+          description: Not Implemented
           schema:
              $ref: '#/definitions/Error'
       tags:


### PR DESCRIPTION
## Purpose
> Use username when creating the associations instead of using userId.