### PR TITLE
Support single user delete function in user association API

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/MeApi.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
+import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
@@ -46,11 +47,12 @@ public class MeApi  {
    @Autowired
    private MeApiService delegate;
 
+    @Valid
     @DELETE
     @Path("/associations")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Delete all my user associations", notes = "This API is used to delete all associations of the auhtentiated user.\n\n  <b>Permission required:</b>\n\n  * /permission/admin/login\n", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Delete my user associations", notes = "This API is used to delete a given association(s) of the auhtentiated user.\n\n  <b>Permission required:</b>\n\n  * /permission/admin/login\n", response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No content"),
         
@@ -60,10 +62,12 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response meAssociationsDelete()
+    public Response meAssociationsDelete(@ApiParam(value = "Username of the user that need to be removed from authenticated user's associations.") @QueryParam("username")  String username,
+    @ApiParam(value = "UserStore domain of the user that need to be removed from authenticated user's associations.") @QueryParam("userStoreDomain")  String userStoreDomain)
     {
-    return delegate.meAssociationsDelete();
+    return delegate.meAssociationsDelete(username,userStoreDomain);
     }
+    @Valid
     @GET
     @Path("/associations")
     @Consumes({ "application/json" })
@@ -84,6 +88,7 @@ public class MeApi  {
     {
     return delegate.meAssociationsGet();
     }
+    @Valid
     @POST
     @Path("/associations")
     @Consumes({ "application/json" })
@@ -102,10 +107,11 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response meAssociationsPost(@ApiParam(value = "User details to be associated. userId should be the fully qalified username of the user." ,required=true ) AssociationUserRequestDTO association)
+    public Response meAssociationsPost(@ApiParam(value = "User details to be associated. userId should be the fully qalified username of the user." ,required=true ) @Valid AssociationUserRequestDTO association)
     {
     return delegate.meAssociationsPost(association);
     }
+    @Valid
     @PUT
     @Path("/associations/switch")
     @Consumes({ "application/json" })
@@ -124,7 +130,7 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 501, message = "Not Implemented") })
 
-    public Response meAssociationsSwitchPut(@ApiParam(value = "" ,required=true ) AssociationSwitchRequestDTO switchUserReqeust)
+    public Response meAssociationsSwitchPut(@ApiParam(value = "" ,required=true ) @Valid AssociationSwitchRequestDTO switchUserReqeust)
     {
     return delegate.meAssociationsSwitchPut(switchUserReqeust);
     }

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/MeApiService.java
@@ -32,7 +32,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class MeApiService {
-    public abstract Response meAssociationsDelete();
+    public abstract Response meAssociationsDelete(String username,String userStoreDomain);
     public abstract Response meAssociationsGet();
     public abstract Response meAssociationsPost(AssociationUserRequestDTO association);
     public abstract Response meAssociationsSwitchPut(AssociationSwitchRequestDTO switchUserReqeust);

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/UserIdApi.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
+import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
@@ -45,6 +46,7 @@ public class UserIdApi  {
    @Autowired
    private UserIdApiService delegate;
 
+    @Valid
     @DELETE
     @Path("/associations")
     @Consumes({ "application/json" })
@@ -65,6 +67,7 @@ public class UserIdApi  {
     {
     return delegate.userIdAssociationsDelete(userId);
     }
+    @Valid
     @GET
     @Path("/associations")
     @Consumes({ "application/json" })
@@ -87,6 +90,7 @@ public class UserIdApi  {
     {
     return delegate.userIdAssociationsGet(userId);
     }
+    @Valid
     @POST
     @Path("/associations")
     @Consumes({ "application/json" })
@@ -105,7 +109,7 @@ public class UserIdApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response userIdAssociationsPost(@ApiParam(value = "Fully qualified username of the associating user." ,required=true ) AssociationRequestDTO association,
+    public Response userIdAssociationsPost(@ApiParam(value = "Fully qualified username of the associating user." ,required=true ) @Valid AssociationRequestDTO association,
     @ApiParam(value = "user id",required=true ) @PathParam("user-id")  String userId)
     {
     return delegate.userIdAssociationsPost(association,userId);

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationRequestDTO.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.rest.api.user.association.v1.dto.PropertyDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -34,10 +35,10 @@ import javax.validation.constraints.Pattern;
 public class AssociationRequestDTO  {
   
   
-  
+  @Valid 
   private String associateUserId = null;
   
-  
+  @Valid 
   private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationSwitchRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationSwitchRequestDTO.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.rest.api.user.association.v1.dto.PropertyDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -34,10 +35,10 @@ import javax.validation.constraints.Pattern;
 public class AssociationSwitchRequestDTO  {
   
   
-  
+  @Valid 
   private String userId = null;
   
-  
+  @Valid 
   private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationUserRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/AssociationUserRequestDTO.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.rest.api.user.association.v1.dto.PropertyDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -34,13 +35,13 @@ import javax.validation.constraints.Pattern;
 public class AssociationUserRequestDTO  {
   
   
-  
+  @Valid 
   private String userId = null;
   
-  
+  @Valid 
   private String password = null;
   
-  
+  @Valid 
   private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/ErrorDTO.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.rest.api.user.association.v1.dto;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -31,16 +32,16 @@ import javax.validation.constraints.Pattern;
 public class ErrorDTO  {
   
   
-  @NotNull 
+  @Valid @NotNull(message = "Property code cannot be null.") 
   private String code = null;
   
-  @NotNull 
+  @Valid @NotNull(message = "Property message cannot be null.") 
   private String message = null;
   
-  
+  @Valid 
   private String description = null;
   
-  
+  @Valid 
   private String traceId = null;
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/PropertyDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/PropertyDTO.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.rest.api.user.association.v1.dto;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -31,10 +32,10 @@ import javax.validation.constraints.Pattern;
 public class PropertyDTO  {
   
   
-  
+  @Valid 
   private String key = null;
   
-  
+  @Valid 
   private String value = null;
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/UserDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/association/v1/dto/UserDTO.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.rest.api.user.association.v1.dto;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -31,16 +32,16 @@ import javax.validation.constraints.Pattern;
 public class UserDTO  {
   
   
-  
+  @Valid 
   private String userId = null;
   
-  
+  @Valid 
   private String username = null;
   
-  
+  @Valid 
   private String userStoreDomain = null;
   
-  
+  @Valid 
   private String tenantDomain = null;
 
   

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
@@ -1,7 +1,9 @@
 package org.wso2.carbon.identity.rest.api.user.association.v1.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.rest.api.user.association.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.dto.AssociationSwitchRequestDTO;
@@ -25,10 +27,20 @@ public class MeApiServiceImpl extends MeApiService {
     private UserAssociationService userAssociationService;
 
     @Override
-    public Response meAssociationsDelete() {
+    public Response meAssociationsDelete(String username, String userStoreDomain) {
 
-        userAssociationService.deleteUserAccountAssociation(getUserId());
-        return Response.noContent().build();
+        if (StringUtils.isBlank(username)) {
+            userAssociationService.deleteUserAccountAssociation(getUserId());
+            return Response.noContent().build();
+        } else {
+            User user = new User();
+            user.setUserName(username);
+            if (StringUtils.isNotBlank(userStoreDomain)) {
+                user.setUserStoreDomain(userStoreDomain);
+            }
+            userAssociationService.deleteUserAccountAssociation(user.toFullQualifiedUsername());
+            return Response.noContent().build();
+        }
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
@@ -126,13 +126,24 @@ paths:
              $ref: '#/definitions/Error'
 
     delete:
-      summary: Delete all my user associations
+      summary: Delete my user associations
       description: |
-        This API is used to delete all associations of the auhtentiated user.
+        This API is used to delete a given association(s) of the auhtentiated user.
 
           <b>Permission required:</b>
 
           * /permission/admin/login
+      parameters:
+        - name: username
+          in: query
+          description:  Username of the user that need to be removed from authenticated user's associations.
+          required: false
+          type: string
+        - name: userStoreDomain
+          in: query
+          description:  UserStore domain of the user that need to be removed from authenticated user's associations.
+          required: false
+          type: string
       responses:
         204:
           description: No content


### PR DESCRIPTION
- Resolves wso2/product-is#6489

This endpoint is used to delete all user associations or only selected user associations.

To delete all user associations of the authenticated user, use following curl command :

`curl -X DELETE "https://localhost:9443/t/{tenant-domain}/api/users/v1/me/associations" -H "accept: application/json"`

To delete a selected user association of the authenticated user, use following curl command :

`curl -X DELETE "https://localhost:9443/t/{tenant-domain}/api/users/v1/me/associations?username=John&userStoreDomain=Primary" -H "accept: application/json"`