### PR TITLE
Fix for issue when Trying to view the challenge question of a non-existing user returns 500 internal server error

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/function/UniqueIdToUser.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/function/UniqueIdToUser.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
 import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.function.BiFunction;
@@ -76,6 +77,13 @@ public class UniqueIdToUser implements BiFunction<RealmService, String[], User> 
         try {
             user = uniqueIdEnabledUserStoreManager.getUserWithID(userId, null, null);
         } catch (UserStoreException e) {
+            if (UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode().equals(e.getErrorCode())) {
+                throw new APIError(Response.Status.NOT_FOUND, new ErrorResponse.Builder()
+                        .withCode(ERROR_CODE_INVALID_USERNAME.getCode())
+                        .withMessage(ERROR_CODE_INVALID_USERNAME.getMessage())
+                        .withDescription(ERROR_CODE_INVALID_USERNAME.getDescription())
+                        .build(log, e, "Invalid userId: " + userId));
+            }
             log.error("Unable to retrieve user for the given user id: " + userId, e);
         }
         if (user == null) {


### PR DESCRIPTION
## Purpose
For the issue https://github.com/wso2/product-is/issues/7628, when user store exception occurs need to check its caused by user not found. If so, need to through API Error. Please merge after https://github.com/wso2/carbon-kernel/pull/2609