### PR TITLE
Remove message body for 401 and 403 responses in user apis swagger doc

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/resources/application.yaml
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/resources/application.yaml
@@ -172,10 +172,6 @@ components:
             $ref: '#/components/schemas/Error'
     Unauthorized:
       description: Unauthorized.
-      content:
-        application/json':
-          schema:
-            $ref: '#/components/schemas/Error'
     ServerError:
       description: Internal Server Error.
       content:
@@ -196,10 +192,6 @@ components:
             $ref: '#/components/schemas/Error'
     Forbidden:
       description: Resource Forbidden.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
   securitySchemes:
     BasicAuth:
       type: http

--- a/components/org.wso2.carbon.identity.api.user.approval/org.wso2.carbon.identity.rest.api.user.approval.v1/src/main/resources/approval.yaml
+++ b/components/org.wso2.carbon.identity.api.user.approval/org.wso2.carbon.identity.rest.api.user.approval.v1/src/main/resources/approval.yaml
@@ -381,8 +381,6 @@ responses:
       $ref: '#/definitions/Error'
   Unauthorized:
     description: Unauthorized
-    schema:
-      $ref: '#/definitions/Error'
   ServerError:
     description: Internal Server Error
     schema:

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v1/src/main/resources/authorizedApps.yaml
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v1/src/main/resources/authorizedApps.yaml
@@ -278,8 +278,6 @@ responses:
       $ref: '#/definitions/Error'
   Unauthorized:
     description: Unauthorized
-    schema:
-      $ref: '#/definitions/Error'
   ServerError:
     description: Internal Server Error
     schema:

--- a/components/org.wso2.carbon.identity.api.user.fido2/org.wso2.carbon.identity.api.user.fido2.v1/src/main/resources/fido.yaml
+++ b/components/org.wso2.carbon.identity.api.user.fido2/org.wso2.carbon.identity.api.user.fido2.v1/src/main/resources/fido.yaml
@@ -115,8 +115,6 @@ paths:
             $ref: '#/definitions/Error'
         401:
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
         409:
           description: Conflict
           schema:
@@ -156,8 +154,6 @@ paths:
             $ref: '#/definitions/Error'
         401:
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
         409:
           description: Conflict
           schema:
@@ -197,8 +193,6 @@ paths:
             $ref: '#/definitions/Error'
         401:
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
         500:
           description: Server Error
           schema:
@@ -235,8 +229,6 @@ paths:
             $ref: '#/definitions/Error'
         401:
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
         409:
           description: Conflict
           schema:

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -215,8 +215,6 @@ responses:
     description: Resource Not Found
   Unauthorized:
     description: Unauthorized
-    schema:
-      $ref: '#/definitions/Error'
   ServerError:
     description: Internal Server Error
     schema:


### PR DESCRIPTION
## Purpose
Resolving https://github.com/wso2/product-is/issues/6414
Remove message body for 401 and 403 responses in user apis swagger doc. Please note that each commit is for each yaml file in api server. In each yaml file schema and content(body) deleted for both responses. Need to update the doc.