### PR TITLE
Enable tenant qualified urls for recovery API responses

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/PasswordRecoveryService.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/PasswordRecoveryService.java
@@ -228,12 +228,12 @@ public class PasswordRecoveryService {
         // Add confirm API call information.
         apiCallsArrayList.add(RecoveryUtil.buildApiCall(Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getType(),
                 Constants.RelationStates.NEXT_REL, RecoveryUtil
-                        .buildUri(tenantDomain, Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getApiUrl(),
+                        .buildURIForBody(tenantDomain, Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         // Add resend confirmation code API call information.
         apiCallsArrayList.add(RecoveryUtil.buildApiCall(Constants.APICall.RESEND_CONFIRMATION_API.getType(),
                 Constants.RelationStates.RESEND_REL, RecoveryUtil
-                        .buildUri(tenantDomain, Constants.APICall.RESEND_CONFIRMATION_API.getApiUrl(),
+                        .buildURIForBody(tenantDomain, Constants.APICall.RESEND_CONFIRMATION_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType()
                 .equals(resendConfirmationDTO.getNotificationChannel())) {
@@ -290,7 +290,7 @@ public class PasswordRecoveryService {
         ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
         apiCallsArrayList.add(RecoveryUtil
                 .buildApiCall(Constants.APICall.RESET_PASSWORD_API.getType(), Constants.RelationStates.NEXT_REL,
-                        RecoveryUtil.buildUri(tenantDomain, Constants.APICall.RESET_PASSWORD_API.getApiUrl(),
+                        RecoveryUtil.buildURIForBody(tenantDomain, Constants.APICall.RESET_PASSWORD_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         ResetCodeResponse resetCodeResponseDTO = new ResetCodeResponse();
         resetCodeResponseDTO.setResetCode(passwordResetCodeDTO.getPasswordResetCode());
@@ -313,12 +313,12 @@ public class PasswordRecoveryService {
         ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
         apiCallsArrayList.add(RecoveryUtil.buildApiCall(Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getType(),
                 Constants.RelationStates.NEXT_REL, RecoveryUtil
-                        .buildUri(tenantDomain, Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getApiUrl(),
+                        .buildURIForBody(tenantDomain, Constants.APICall.CONFIRM_PASSWORD_RECOVERY_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         // Add resend confirmation code API call information.
         apiCallsArrayList.add(RecoveryUtil.buildApiCall(Constants.APICall.RESEND_CONFIRMATION_API.getType(),
                 Constants.RelationStates.RESEND_REL, RecoveryUtil
-                        .buildUri(tenantDomain, Constants.APICall.RESEND_CONFIRMATION_API.getApiUrl(),
+                        .buildURIForBody(tenantDomain, Constants.APICall.RESEND_CONFIRMATION_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
             return Response.ok()
@@ -425,7 +425,7 @@ public class PasswordRecoveryService {
             ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
             apiCallsArrayList.add(RecoveryUtil.buildApiCall(Constants.APICall.RECOVER_PASSWORD_API.getType(),
                     Constants.RelationStates.NEXT_REL, RecoveryUtil
-                            .buildUri(tenantDomain, Constants.APICall.RECOVER_PASSWORD_API.getApiUrl(),
+                            .buildURIForBody(tenantDomain, Constants.APICall.RECOVER_PASSWORD_API.getApiUrl(),
                                     Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
             RecoveryChannelInformation recoveryChannelInformation = buildRecoveryChannelInformation(
                     recoveryInformationDTO);
@@ -439,7 +439,7 @@ public class PasswordRecoveryService {
             ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
             apiCallsArrayList.add(RecoveryUtil
                     .buildApiCall(Constants.APICall.RECOVER_WITH_SECURITY_QUESTIONS_API.getType(),
-                            Constants.RelationStates.NEXT_REL, RecoveryUtil.buildUri(tenantDomain,
+                            Constants.RelationStates.NEXT_REL, RecoveryUtil.buildURIForBody(tenantDomain,
                                     Constants.APICall.RECOVER_WITH_SECURITY_QUESTIONS_API.getApiUrl(),
                                     Constants.CHALLENGE_QUESTIONS_ENDPOINT_BASEPATH),
                             recoveryInformationDTO.getUsername()));

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/UsernameRecoveryService.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/UsernameRecoveryService.java
@@ -164,7 +164,7 @@ public class UsernameRecoveryService {
         ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
         apiCallsArrayList.add(RecoveryUtil
                 .buildApiCall(Constants.APICall.RECOVER_USERNAME_API.getType(), Constants.RelationStates.NEXT_REL,
-                        RecoveryUtil.buildUri(tenantDomain, Constants.APICall.RECOVER_USERNAME_API.getApiUrl(),
+                        RecoveryUtil.buildURIForBody(tenantDomain, Constants.APICall.RECOVER_USERNAME_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         // Build recovery type information.
         AccountRecoveryType accountRecoveryType = new AccountRecoveryType();


### PR DESCRIPTION
## Purpose
> Fix : https://github.com/wso2/product-is/issues/8296
> Enabled tenant qualified URLs for recovery APIs in user APIs.