### PR TITLE
Improve initiate password recovery API response for question based recovery when answers not set for min. of questions

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/PasswordRecoveryService.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/PasswordRecoveryService.java
@@ -419,7 +419,7 @@ public class PasswordRecoveryService {
 
         ArrayList<AccountRecoveryType> accountRecoveryTypes = new ArrayList<>();
         boolean isNotificationBasedRecoveryEnabled = recoveryInformationDTO.isNotificationBasedRecoveryEnabled();
-        boolean isQuestionBasedRecoveryEnabled = recoveryInformationDTO.isQuestionBasedRecoveryEnabled();
+        boolean isQuestionBasedRecoveryAllowedForUser = recoveryInformationDTO.isQuestionBasedRecoveryAllowedForUser();
         if (isNotificationBasedRecoveryEnabled) {
             // Build next API calls list.
             ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
@@ -434,7 +434,7 @@ public class PasswordRecoveryService {
                     Constants.RECOVERY_WITH_NOTIFICATIONS, recoveryChannelInformation, apiCallsArrayList);
             accountRecoveryTypes.add(accountRecoveryType);
         }
-        if (isQuestionBasedRecoveryEnabled) {
+        if (isQuestionBasedRecoveryAllowedForUser) {
             // Build next API calls list.
             ArrayList<APICall> apiCallsArrayList = new ArrayList<>();
             apiCallsArrayList.add(RecoveryUtil

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
-        <identity.governance.version>1.4.24-SNAPSHOT</identity.governance.version>
+        <identity.governance.version>1.4.28</identity.governance.version>
         <carbon.identity.framework.version>5.17.66</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
-        <identity.governance.version>1.3.39</identity.governance.version>
+        <identity.governance.version>1.4.24-SNAPSHOT</identity.governance.version>
         <carbon.identity.framework.version>5.17.66</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>


### PR DESCRIPTION
## Purpose
PR [1] adds an improvement to not to display question based recovery option in the initiate password recovery API response when answers are not set for min. of questions that are required for recovery. This PR adds this new validation check for constructing the proper response body for initiate password recovery API.

Merge after: https://github.com/wso2-extensions/identity-governance/pull/405

Related issue: https://github.com/wso2/product-is/issues/8905

[1] https://github.com/wso2-extensions/identity-governance/pull/405