### PR TITLE
Return application resource id with the sessions object

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,23 +32,24 @@ import java.io.InputStream;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
+import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
 @Path("/me")
-
-
 @io.swagger.annotations.Api(value = "/me", description = "the me API")
 public class MeApi  {
 
-   @Autowired
-   private MeApiService delegate;
+    @Autowired
+    private MeApiService delegate;
 
+    @Valid
     @GET
     @Path("/sessions")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve active sessions of the authenticated user", notes = "A user can have multiple active sessions. This API retrieves information of all the active sessions of the authenticated user.\n<b>Permission required:</b>\n * /permission/admin/login\n", response = SessionsDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Retrieve active sessions of the authenticated user",
+            notes = "A user can have multiple active sessions. This API retrieves information of all the active sessions of the authenticated user. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login\n",
+            response = SessionsDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved session information"),
         
@@ -63,15 +64,17 @@ public class MeApi  {
     public Response getSessionsOfLoggedInUser(@ApiParam(value = "Maximum number of records to return.\n_This parameter is not supported yet._\n") @QueryParam("limit")  Integer limit,
     @ApiParam(value = "Number of records to skip for pagination.\n_This parameter is not supported yet._\n") @QueryParam("offset")  Integer offset,
     @ApiParam(value = "Condition to filter the retrival of records.\n_This parameter is not supported yet._\n") @QueryParam("filter")  String filter,
-    @ApiParam(value = "Define the order in which the retrieved records should be sorted.\n_This parameter is not supported yet._\n") @QueryParam("sort")  String sort)
-    {
-    return delegate.getSessionsOfLoggedInUser(limit,offset,filter,sort);
+    @ApiParam(value = "Define the order in which the retrieved records should be sorted.\n_This parameter is not supported yet._\n") @QueryParam("sort")  String sort) {
+
+        return delegate.getSessionsOfLoggedInUser(limit,offset,filter,sort);
     }
+
+    @Valid
     @DELETE
     @Path("/sessions/{session-id}")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Terminate a given session of the authenticated user", notes = "A user has multiple active sessions. This API terminates a specific session of the authenticated user identified by the session-id.\n<b>Permission required:</b>\n * /permission/admin/login\n", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Terminate a given session of the authenticated user",
+            notes = "A user has multiple active sessions. This API terminates a specific session of the authenticated user identified by the session-id. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login\n",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content"),
         
@@ -83,15 +86,17 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error") })
 
-    public Response terminateSessionByLoggedInUser(@ApiParam(value = "ID of the session.",required=true ) @PathParam("session-id")  String sessionId)
-    {
-    return delegate.terminateSessionByLoggedInUser(sessionId);
+    public Response terminateSessionByLoggedInUser(@ApiParam(value = "ID of the session.",required=true ) @PathParam("session-id")  String sessionId) {
+
+        return delegate.terminateSessionByLoggedInUser(sessionId);
     }
+
+    @Valid
     @DELETE
     @Path("/sessions")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Terminate all the active sessions of the authenticated user", notes = "A user has multiple active sessions. This API terminates all the active sessions of the authenticated user.\n<b>Permission required:</b>\n * /permission/admin/login\n", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Terminate all the active sessions of the authenticated user",
+            notes = "A user has multiple active sessions. This API terminates all the active sessions of the authenticated user. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login\n",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content"),
         
@@ -103,9 +108,9 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error") })
 
-    public Response terminateSessionsByLoggedInUser()
-    {
-    return delegate.terminateSessionsByLoggedInUser();
-    }
-}
+    public Response terminateSessionsByLoggedInUser() {
 
+        return delegate.terminateSessionsByLoggedInUser();
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,11 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class MeApiService {
-    public abstract Response getSessionsOfLoggedInUser(Integer limit,Integer offset,String filter,String sort);
-    public abstract Response terminateSessionByLoggedInUser(String sessionId);
-    public abstract Response terminateSessionsByLoggedInUser();
-}
 
+    public abstract Response getSessionsOfLoggedInUser(Integer limit, Integer offset, String filter, String sort);
+
+    public abstract Response terminateSessionByLoggedInUser(String sessionId);
+
+    public abstract Response terminateSessionsByLoggedInUser();
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/MeApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,23 +32,24 @@ import java.io.InputStream;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
+import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
 @Path("/{user-id}")
-
-
 @io.swagger.annotations.Api(value = "/{user-id}", description = "the {user-id} API")
 public class UserIdApi  {
 
-   @Autowired
-   private UserIdApiService delegate;
+    @Autowired
+    private UserIdApiService delegate;
 
+    @Valid
     @GET
     @Path("/sessions")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Get active sessions", notes = "Retrieves information related to the active sessions of a user identified by the user-id.", response = SessionsDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Get active sessions",
+            notes = "Retrieves information related to the active sessions of a user identified by the user-id. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/authentication/session/view <br> <b>Scope required:</b> <br> * internal_session_view",
+            response = SessionsDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Successfully retrieved session information."),
         
@@ -66,15 +67,17 @@ public class UserIdApi  {
     @ApiParam(value = "Maximum number of records to return.\n_This parameter is not supported yet._\n") @QueryParam("limit")  Integer limit,
     @ApiParam(value = "Number of records to skip for pagination.\n_This parameter is not supported yet._\n") @QueryParam("offset")  Integer offset,
     @ApiParam(value = "Condition to filter the retrival of records.\n_This parameter is not supported yet._\n") @QueryParam("filter")  String filter,
-    @ApiParam(value = "Define the order in which the retrieved records should be sorted.\n_This parameter is not supported yet._\n") @QueryParam("sort")  String sort)
-    {
-    return delegate.getSessionsByUserId(userId,limit,offset,filter,sort);
+    @ApiParam(value = "Define the order in which the retrieved records should be sorted.\n_This parameter is not supported yet._\n") @QueryParam("sort")  String sort) {
+
+        return delegate.getSessionsByUserId(userId,limit,offset,filter,sort);
     }
+
+    @Valid
     @DELETE
     @Path("/sessions/{session-id}")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Terminate a session", notes = "Terminate a specific session of a user by the session-id.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Terminate a session",
+            notes = "Terminate a specific session of a user by the session-id. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/authentication/session/delete <br> <b>Scope required:</b> <br> * internal_session_delete",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content"),
         
@@ -85,15 +88,17 @@ public class UserIdApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error") })
 
     public Response terminateSessionBySessionId(@ApiParam(value = "ID of the user.",required=true ) @PathParam("user-id")  String userId,
-    @ApiParam(value = "ID of the session.",required=true ) @PathParam("session-id")  String sessionId)
-    {
-    return delegate.terminateSessionBySessionId(userId,sessionId);
+    @ApiParam(value = "ID of the session.",required=true ) @PathParam("session-id")  String sessionId) {
+
+        return delegate.terminateSessionBySessionId(userId,sessionId);
     }
+
+    @Valid
     @DELETE
     @Path("/sessions")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Terminate all sessions", notes = "Delete all the sessions of a user identified by the user-id.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Terminate all sessions",
+            notes = "Delete all the sessions of a user identified by the user-id. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/authentication/session/delete <br> <b>Scope required:</b> <br> * internal_session_delete",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content"),
         
@@ -103,9 +108,9 @@ public class UserIdApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error") })
 
-    public Response terminateSessionsByUserId(@ApiParam(value = "ID of the user.",required=true ) @PathParam("user-id")  String userId)
-    {
-    return delegate.terminateSessionsByUserId(userId);
-    }
-}
+    public Response terminateSessionsByUserId(@ApiParam(value = "ID of the user.",required=true ) @PathParam("user-id")  String userId) {
 
+        return delegate.terminateSessionsByUserId(userId);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,11 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class UserIdApiService {
-    public abstract Response getSessionsByUserId(String userId,Integer limit,Integer offset,String filter,String sort);
-    public abstract Response terminateSessionBySessionId(String userId,String sessionId);
-    public abstract Response terminateSessionsByUserId(String userId);
-}
 
+    public abstract Response getSessionsByUserId(String userId, Integer limit, Integer offset, String filter, String sort);
+
+    public abstract Response terminateSessionBySessionId(String userId, String sessionId);
+
+    public abstract Response terminateSessionsByUserId(String userId);
+
+}

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/UserIdApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,80 +16,92 @@
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class ApplicationDTO  {
-  
-  
-  @NotNull 
-  private String subject = null;
-  
-  @NotNull 
-  private String appName = null;
-  
-  @NotNull 
-  private String appId = null;
+public class ApplicationDTO {
 
-  
-  /**
-   * Username of the logged in user for the application.
-   **/
-  @ApiModelProperty(required = true, value = "Username of the logged in user for the application.")
-  @JsonProperty("subject")
-  public String getSubject() {
-    return subject;
-  }
-  public void setSubject(String subject) {
-    this.subject = subject;
-  }
+    @Valid 
+    @NotNull(message = "Property subject cannot be null.") 
+    private String subject = null;
 
-  
-  /**
-   * Name of the application.
-   **/
-  @ApiModelProperty(required = true, value = "Name of the application.")
-  @JsonProperty("appName")
-  public String getAppName() {
-    return appName;
-  }
-  public void setAppName(String appName) {
-    this.appName = appName;
-  }
+    @Valid 
+    @NotNull(message = "Property appName cannot be null.") 
+    private String appName = null;
 
-  
-  /**
-   * ID of the application.
-   **/
-  @ApiModelProperty(required = true, value = "ID of the application.")
-  @JsonProperty("appId")
-  public String getAppId() {
-    return appId;
-  }
-  public void setAppId(String appId) {
-    this.appId = appId;
-  }
+    @Valid 
+    @NotNull(message = "Property appId cannot be null.") 
+    private String appId = null;
 
-  
+    @Valid 
+    @NotNull(message = "Property id cannot be null.") 
+    private String id = null;
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ApplicationDTO {\n");
-    
-    sb.append("  subject: ").append(subject).append("\n");
-    sb.append("  appName: ").append(appName).append("\n");
-    sb.append("  appId: ").append(appId).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Username of the logged in user for the application.
+    **/
+    @ApiModelProperty(required = true, value = "Username of the logged in user for the application.")
+    @JsonProperty("subject")
+    public String getSubject() {
+        return subject;
+    }
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+    * Name of the application.
+    **/
+    @ApiModelProperty(required = true, value = "Name of the application.")
+    @JsonProperty("appName")
+    public String getAppName() {
+        return appName;
+    }
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    /**
+    * ID of the application.
+    **/
+    @ApiModelProperty(required = true, value = "ID of the application.")
+    @JsonProperty("appId")
+    public String getAppId() {
+        return appId;
+    }
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    /**
+    * Unique ID of the application.
+    **/
+    @ApiModelProperty(required = true, value = "Unique ID of the application.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationDTO {\n");
+        
+        sb.append("    subject: ").append(subject).append("\n");
+        sb.append("    appName: ").append(appName).append("\n");
+        sb.append("    appId: ").append(appId).append("\n");
+        sb.append("    id: ").append(id).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ApplicationDTO.java
@@ -27,6 +27,10 @@ import javax.validation.constraints.Pattern;
 public class ApplicationDTO {
 
     @Valid 
+    @NotNull(message = "Property id cannot be null.") 
+    private String id = null;
+
+    @Valid 
     @NotNull(message = "Property subject cannot be null.") 
     private String subject = null;
 
@@ -38,9 +42,17 @@ public class ApplicationDTO {
     @NotNull(message = "Property appId cannot be null.") 
     private String appId = null;
 
-    @Valid 
-    @NotNull(message = "Property id cannot be null.") 
-    private String id = null;
+    /**
+    * Unique ID of the application.
+    **/
+    @ApiModelProperty(required = true, value = "Unique ID of the application.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
     /**
     * Username of the logged in user for the application.
@@ -78,28 +90,16 @@ public class ApplicationDTO {
         this.appId = appId;
     }
 
-    /**
-    * Unique ID of the application.
-    **/
-    @ApiModelProperty(required = true, value = "Unique ID of the application.")
-    @JsonProperty("id")
-    public String getId() {
-        return id;
-    }
-    public void setId(String id) {
-        this.id = id;
-    }
-
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class ApplicationDTO {\n");
         
+        sb.append("    id: ").append(id).append("\n");
         sb.append("    subject: ").append(subject).append("\n");
         sb.append("    appName: ").append(appName).append("\n");
         sb.append("    appId: ").append(appId).append("\n");
-        sb.append("    id: ").append(id).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/ErrorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,93 +16,86 @@
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class ErrorDTO  {
-  
-  
-  @NotNull 
-  private String code = null;
-  
-  @NotNull 
-  private String message = null;
-  
-  
-  private String description = null;
-  
-  
-  private String traceId = null;
+public class ErrorDTO {
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("code")
-  public String getCode() {
-    return code;
-  }
-  public void setCode(String code) {
-    this.code = code;
-  }
+    @Valid 
+    @NotNull(message = "Property code cannot be null.") 
+    private String code = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("message")
-  public String getMessage() {
-    return message;
-  }
-  public void setMessage(String message) {
-    this.message = message;
-  }
+    @Valid 
+    @NotNull(message = "Property message cannot be null.") 
+    private String message = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    @Valid 
+    private String description = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("traceId")
-  public String getTraceId() {
-    return traceId;
-  }
-  public void setTraceId(String traceId) {
-    this.traceId = traceId;
-  }
+    @Valid 
+    private String traceId = null;
 
-  
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("code")
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ErrorDTO {\n");
-    
-    sb.append("  code: ").append(code).append("\n");
-    sb.append("  message: ").append(message).append("\n");
-    sb.append("  description: ").append(description).append("\n");
-    sb.append("  traceId: ").append(traceId).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("traceId")
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorDTO {\n");
+        
+        sb.append("    code: ").append(code).append("\n");
+        sb.append("    message: ").append(message).append("\n");
+        sb.append("    description: ").append(description).append("\n");
+        sb.append("    traceId: ").append(traceId).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,131 +19,120 @@ package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.ApplicationDTO;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class SessionDTO  {
-  
-  
-  
-  private List<ApplicationDTO> applications = new ArrayList<ApplicationDTO>();
-  
-  
-  private String userAgent = null;
-  
-  
-  private String ip = null;
-  
-  
-  private String loginTime = null;
-  
-  
-  private String lastAccessTime = null;
-  
-  
-  private String id = null;
+public class SessionDTO {
 
-  
-  /**
-   * List of applications in the session.
-   **/
-  @ApiModelProperty(value = "List of applications in the session.")
-  @JsonProperty("applications")
-  public List<ApplicationDTO> getApplications() {
-    return applications;
-  }
-  public void setApplications(List<ApplicationDTO> applications) {
-    this.applications = applications;
-  }
+    @Valid 
+    private List<ApplicationDTO> applications = new ArrayList<ApplicationDTO>();
 
-  
-  /**
-   * User agent of the session.
-   **/
-  @ApiModelProperty(value = "User agent of the session.")
-  @JsonProperty("userAgent")
-  public String getUserAgent() {
-    return userAgent;
-  }
-  public void setUserAgent(String userAgent) {
-    this.userAgent = userAgent;
-  }
+    @Valid 
+    private String userAgent = null;
 
-  
-  /**
-   * IP address of the session.
-   **/
-  @ApiModelProperty(value = "IP address of the session.")
-  @JsonProperty("ip")
-  public String getIp() {
-    return ip;
-  }
-  public void setIp(String ip) {
-    this.ip = ip;
-  }
+    @Valid 
+    private String ip = null;
 
-  
-  /**
-   * Login time of the session.
-   **/
-  @ApiModelProperty(value = "Login time of the session.")
-  @JsonProperty("loginTime")
-  public String getLoginTime() {
-    return loginTime;
-  }
-  public void setLoginTime(String loginTime) {
-    this.loginTime = loginTime;
-  }
+    @Valid 
+    private String loginTime = null;
 
-  
-  /**
-   * Last access time of the session.
-   **/
-  @ApiModelProperty(value = "Last access time of the session.")
-  @JsonProperty("lastAccessTime")
-  public String getLastAccessTime() {
-    return lastAccessTime;
-  }
-  public void setLastAccessTime(String lastAccessTime) {
-    this.lastAccessTime = lastAccessTime;
-  }
+    @Valid 
+    private String lastAccessTime = null;
 
-  
-  /**
-   * ID of the session.
-   **/
-  @ApiModelProperty(value = "ID of the session.")
-  @JsonProperty("id")
-  public String getId() {
-    return id;
-  }
-  public void setId(String id) {
-    this.id = id;
-  }
+    @Valid 
+    private String id = null;
 
-  
+    /**
+    * List of applications in the session.
+    **/
+    @ApiModelProperty(value = "List of applications in the session.")
+    @JsonProperty("applications")
+    public List<ApplicationDTO> getApplications() {
+        return applications;
+    }
+    public void setApplications(List<ApplicationDTO> applications) {
+        this.applications = applications;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class SessionDTO {\n");
-    
-    sb.append("  applications: ").append(applications).append("\n");
-    sb.append("  userAgent: ").append(userAgent).append("\n");
-    sb.append("  ip: ").append(ip).append("\n");
-    sb.append("  loginTime: ").append(loginTime).append("\n");
-    sb.append("  lastAccessTime: ").append(lastAccessTime).append("\n");
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * User agent of the session.
+    **/
+    @ApiModelProperty(value = "User agent of the session.")
+    @JsonProperty("userAgent")
+    public String getUserAgent() {
+        return userAgent;
+    }
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    /**
+    * IP address of the session.
+    **/
+    @ApiModelProperty(value = "IP address of the session.")
+    @JsonProperty("ip")
+    public String getIp() {
+        return ip;
+    }
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    /**
+    * Login time of the session.
+    **/
+    @ApiModelProperty(value = "Login time of the session.")
+    @JsonProperty("loginTime")
+    public String getLoginTime() {
+        return loginTime;
+    }
+    public void setLoginTime(String loginTime) {
+        this.loginTime = loginTime;
+    }
+
+    /**
+    * Last access time of the session.
+    **/
+    @ApiModelProperty(value = "Last access time of the session.")
+    @JsonProperty("lastAccessTime")
+    public String getLastAccessTime() {
+        return lastAccessTime;
+    }
+    public void setLastAccessTime(String lastAccessTime) {
+        this.lastAccessTime = lastAccessTime;
+    }
+
+    /**
+    * ID of the session.
+    **/
+    @ApiModelProperty(value = "ID of the session.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SessionDTO {\n");
+        
+        sb.append("    applications: ").append(applications).append("\n");
+        sb.append("    userAgent: ").append(userAgent).append("\n");
+        sb.append("    ip: ").append(ip).append("\n");
+        sb.append("    loginTime: ").append(loginTime).append("\n");
+        sb.append("    lastAccessTime: ").append(lastAccessTime).append("\n");
+        sb.append("    id: ").append(id).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,62 +19,55 @@ package org.wso2.carbon.identity.rest.api.user.session.v1.dto;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class SessionsDTO  {
-  
-  
-  
-  private String userId = null;
-  
-  
-  private List<SessionDTO> sessions = new ArrayList<SessionDTO>();
+public class SessionsDTO {
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("userId")
-  public String getUserId() {
-    return userId;
-  }
-  public void setUserId(String userId) {
-    this.userId = userId;
-  }
+    @Valid 
+    private String userId = null;
 
-  
-  /**
-   * List of active sessions.
-   **/
-  @ApiModelProperty(value = "List of active sessions.")
-  @JsonProperty("sessions")
-  public List<SessionDTO> getSessions() {
-    return sessions;
-  }
-  public void setSessions(List<SessionDTO> sessions) {
-    this.sessions = sessions;
-  }
+    @Valid 
+    private List<SessionDTO> sessions = new ArrayList<SessionDTO>();
 
-  
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("userId")
+    public String getUserId() {
+        return userId;
+    }
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class SessionsDTO {\n");
-    
-    sb.append("  userId: ").append(userId).append("\n");
-    sb.append("  sessions: ").append(sessions).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * List of active sessions.
+    **/
+    @ApiModelProperty(value = "List of active sessions.")
+    @JsonProperty("sessions")
+    public List<SessionDTO> getSessions() {
+        return sessions;
+    }
+    public void setSessions(List<SessionDTO> sessions) {
+        this.sessions = sessions;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SessionsDTO {\n");
+        
+        sb.append("    userId: ").append(userId).append("\n");
+        sb.append("    sessions: ").append(sessions).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/dto/SessionsDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
@@ -32,6 +32,7 @@ public class ApplicationToExternal implements Function<Application, ApplicationD
     public ApplicationDTO apply(Application application) {
 
         ApplicationDTO applicationDTO = new ApplicationDTO();
+        applicationDTO.setId(application.getUuid());
         applicationDTO.setAppId(application.getAppId());
         applicationDTO.setSubject(application.getSubject());
         applicationDTO.setAppName(application.getAppName());

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/function/ApplicationToExternal.java
@@ -32,7 +32,7 @@ public class ApplicationToExternal implements Function<Application, ApplicationD
     public ApplicationDTO apply(Application application) {
 
         ApplicationDTO applicationDTO = new ApplicationDTO();
-        applicationDTO.setId(application.getUuid());
+        applicationDTO.setId(application.getResourceId());
         applicationDTO.setAppId(application.getAppId());
         applicationDTO.setSubject(application.getSubject());
         applicationDTO.setAppName(application.getAppName());

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -67,12 +67,14 @@ paths:
                       {
                         "subject": "admin",
                         "appName": "travelocity-requestpath",
-                        "appId": "4"
+                        "appId": "4",
+                        "id": "298c5fd8-01ac-4ada-bc10-1ce37f32140b"
                       },
                       {
                         "subject": "admin",
                         "appName": "avis-basic",
-                        "appId": "5"
+                        "appId": "5",
+                        "id": "27385fd8-01ac-4ada-bc10-1ce37363h40b"
                       }
                     ],
                     "userAgent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
@@ -258,6 +260,7 @@ definitions:
       - subject
       - appName
       - appId
+      - id
     properties:
       subject:
         type: string
@@ -271,6 +274,10 @@ definitions:
         type: string
         description: ID of the application.
         example: '012'
+      id:
+        type: string
+        description: Unique ID of the application.
+        example: '298c5fd8-01ac-4ada-bc10-1ce37f32140b'
 
   #-----------------------------------------------------
   # The Session Response  object

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -65,16 +65,16 @@ paths:
                   {
                     "applications": [
                       {
+                        "id": "298c5fd8-01ac-4ada-bc10-1ce37f32140b",
                         "subject": "admin",
                         "appName": "travelocity-requestpath",
-                        "appId": "4",
-                        "id": "298c5fd8-01ac-4ada-bc10-1ce37f32140b"
+                        "appId": "4"
                       },
                       {
+                        "id": "27385fd8-01ac-4ada-bc10-1ce37363h40b",
                         "subject": "admin",
                         "appName": "avis-basic",
-                        "appId": "5",
-                        "id": "27385fd8-01ac-4ada-bc10-1ce37363h40b"
+                        "appId": "5"
                       }
                     ],
                     "userAgent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
@@ -257,11 +257,15 @@ definitions:
   Application:
     type: object
     required:
+      - id
       - subject
       - appName
       - appId
-      - id
     properties:
+      id:
+        type: string
+        description: Unique ID of the application.
+        example: '298c5fd8-01ac-4ada-bc10-1ce37f32140b'
       subject:
         type: string
         description: Username of the logged in user for the application.
@@ -274,10 +278,6 @@ definitions:
         type: string
         description: ID of the application.
         example: '012'
-      id:
-        type: string
-        description: Unique ID of the application.
-        example: '298c5fd8-01ac-4ada-bc10-1ce37f32140b'
 
   #-----------------------------------------------------
   # The Session Response  object

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <identity.governance.version>1.4.28</identity.governance.version>
-        <carbon.identity.framework.version>5.18.78</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.163</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <identity.governance.version>1.4.28</identity.governance.version>
-        <carbon.identity.framework.version>5.18.163</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.164</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>


### PR DESCRIPTION
Part of the fix for wso2/product-is#8387

### Purpose
Return application resource id with the sessions object.

Validated against the following test scenarios.
```
<class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionTest"/>
<class name="org.wso2.identity.integration.test.rest.api.user.session.v1.UserSessionMeSuccessTest"/>
```

### Before merging
- [x] Bump the framework version in **identity-api-user** with this PR
- [x] Merge the PR https://github.com/wso2/carbon-identity-framework/pull/3213


