### PR TITLE
Add a sample for user association request

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
@@ -96,7 +96,7 @@ paths:
             example: |
               {
                 "userId": "john",
-                "password": "userpassword",
+                "password": "userpassword"
               }
       responses:
         201:

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/resources/association.yaml
@@ -91,7 +91,13 @@ paths:
           description:  User details to be associated. userId should be the fully qualified username of the user.
           required: true
           schema:
-            $ref: '#/definitions/AssociationUserRequest'
+            allOf:
+              - $ref: '#/definitions/AssociationUserRequest'
+            example: |
+              {
+                "userId": "john",
+                "password": "userpassword",
+              }
       responses:
         201:
           description: Successfully created


### PR DESCRIPTION
Part of the fix for https://github.com/wso2/product-is/issues/9851
## Purpose
In the API definition, we have used the following as the input request.

```
{
  "userId": "john",
  "password": "userpassword",
  "properties": [
    {
      "key": "test-key",
      "value": "test-value"
    }
  ]
}
```

In the core implementation, we have not used properties attributes. Therefore, the request is misleading. This can be resolved by adding an example.

```
{
  "userId": "john",
  "password": "userpassword"
}