### PR TITLE
API to revoke all the tokens issued for a given application

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.api.user.application.common/src/main/java/org/wso2/carbon/identity/api/user/application/common/ApplicationServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.api.user.application.common/src/main/java/org/wso2/carbon/identity/api/user/application/common/ApplicationServiceHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.user.application.common;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.DiscoverableApplicationManager;
 
 /**
@@ -26,6 +27,7 @@ import org.wso2.carbon.identity.application.mgt.DiscoverableApplicationManager;
 public class ApplicationServiceHolder {
 
     private static DiscoverableApplicationManager discoverableApplicationManager;
+    private static ApplicationManagementService applicationManagementService;
 
     /**
      * Get application management service.
@@ -46,5 +48,25 @@ public class ApplicationServiceHolder {
                                                                  discoverableApplicationManager) {
 
         ApplicationServiceHolder.discoverableApplicationManager = discoverableApplicationManager;
+    }
+
+    /**
+     * Get application management service.
+     *
+     * @return ApplicationManagementService
+     */
+    public static ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Set application management service.
+     *
+     * @param applicationManagementService
+     */
+    public static void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        ApplicationServiceHolder.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.api.user.application.common/src/main/java/org/wso2/carbon/identity/api/user/application/common/factory/ApplicationManagementOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.api.user.application.common/src/main/java/org/wso2/carbon/identity/api/user/application/common/factory/ApplicationManagementOSGIServiceFactory.java
@@ -1,0 +1,36 @@
+package org.wso2.carbon.identity.api.user.application.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the ApplicationManagementService type of object inside the container.
+ */
+public class ApplicationManagementOSGIServiceFactory extends AbstractFactoryBean<ApplicationManagementService> {
+
+    private ApplicationManagementService applicationManagementService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return null;
+    }
+
+    @Override
+    protected ApplicationManagementService createInstance() throws Exception {
+
+        if (this.applicationManagementService == null) {
+            ApplicationManagementService applicationManagementServiceImpl =
+                    (ApplicationManagementService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOSGiService(ApplicationManagementService.class, null);
+            if (applicationManagementServiceImpl != null) {
+                this.applicationManagementService = applicationManagementServiceImpl;
+            } else {
+                throw new Exception("Unable to retrieve ApplicationManagementService.");
+            }
+        }
+        return this.applicationManagementService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/application/v1/core/ApplicationService.java
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/application/v1/core/ApplicationService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.user.common.error.APIError;
 import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.rest.api.user.application.v1.core.function.ApplicationBasicInfoToApiModel;
 import org.wso2.carbon.identity.rest.api.user.application.v1.model.ApplicationListResponse;
 import org.wso2.carbon.identity.rest.api.user.application.v1.model.ApplicationResponse;
@@ -75,6 +76,31 @@ public class ApplicationService {
 
             }
             return buildApplicationResponse(applicationBasicInfo);
+        } catch (IdentityApplicationManagementException e) {
+            ApplicationServiceConstants.ErrorMessage errorEnum =
+                    ApplicationServiceConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_APPLICATION;
+            Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
+            throw handleException(e, errorEnum, status);
+        }
+    }
+
+    /**
+     * Get application from application ID.
+     *
+     * @param applicationId unique identifier of the application
+     * @return a ServiceProvider instance.
+     */
+    public ServiceProvider getServiceProvider(String applicationId) {
+
+        try {
+            String tenantDomain = ContextLoader.getTenantDomainFromContext();
+            ServiceProvider application = ApplicationServiceHolder.getApplicationManagementService().
+                    getServiceProvider(applicationId, tenantDomain);
+            if (application == null) {
+                throw handleNotFoundError(applicationId, ApplicationServiceConstants.ErrorMessage
+                        .ERROR_CODE_APPLICATION_NOT_FOUND);
+            }
+            return application;
         } catch (IdentityApplicationManagementException e) {
             ApplicationServiceConstants.ErrorMessage errorEnum =
                     ApplicationServiceConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_APPLICATION;

--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/resources/META-INF/cxf/application-user-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/resources/META-INF/cxf/application-user-v1-cxf.xml
@@ -25,6 +25,12 @@
           class="org.wso2.carbon.identity.api.user.application.common.ApplicationServiceHolder">
         <property name="discoverableApplicationManager" ref="identityApplicationServiceFactoryBean"/>
     </bean>
+    <bean id="applicationManagementServiceHolderBean"
+          class="org.wso2.carbon.identity.api.user.application.common.ApplicationServiceHolder">
+        <property name="applicationManagementService" ref="applicationManagementServiceFactoryBean"/>
+    </bean>
     <bean id="identityApplicationServiceFactoryBean"
           class="org.wso2.carbon.identity.api.user.application.common.factory.OSGIServiceFactory"/>
+    <bean id="applicationManagementServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.user.application.common.factory.ApplicationManagementOSGIServiceFactory"/>
 </beans>

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/pom.xml
@@ -182,6 +182,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.user.api</groupId>
+            <artifactId>org.wso2.carbon.identity.rest.api.user.application.v1</artifactId>
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/ApplicationsApi.java
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.rest.api.user.authorized.apps.v2;
+
+import io.swagger.annotations.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.dto.ErrorDTO;
+
+import javax.validation.Valid;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+
+@Path("/applications")
+@Api(description = "The applications API")
+public class ApplicationsApi  {
+
+    @Autowired
+    private ApplicationsApiService delegate;
+
+    @Valid
+    @DELETE
+    @Path("/{application-id}/tokens")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Removes all the tokens granted for an application",
+            notes = "Removes all the tokens granted for a given app ID ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "admin" })
+    @ApiResponses(value = {
+        @ApiResponse(code = 204, message = "Item Deleted", response = Void.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource was not found", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = ErrorDTO.class)
+    })
+    public Response deleteIssuedTokensByAppId(@ApiParam(value = "Application ID",required=true)
+                                              @PathParam("application-id") String applicationId) {
+
+        return delegate.deleteIssuedTokensByAppId(applicationId );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/ApplicationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/ApplicationsApiService.java
@@ -1,0 +1,25 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.rest.api.user.authorized.apps.v2;
+
+import javax.ws.rs.core.Response;
+
+
+public interface ApplicationsApiService {
+
+      public Response deleteIssuedTokensByAppId(String applicationId);
+}

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/factories/ApplicationsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/gen/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/factories/ApplicationsApiServiceFactory.java
@@ -1,0 +1,30 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.factories;
+
+import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.ApplicationsApiService;
+import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl.ApplicationsApiServiceImpl;
+
+public class ApplicationsApiServiceFactory {
+
+   private final static ApplicationsApiService service = new ApplicationsApiServiceImpl();
+
+   public static ApplicationsApiService getApplicationsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/core/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/core/Constants.java
@@ -49,7 +49,11 @@ public class Constants {
                         "user: %s"),
         ERROR_CODE_GET_APP_BY_USER("15005", "Error retrieving authorized applications",
                 "A system error occurred while retrieving authorized applications for " +
-                        "user: %s");
+                        "user: %s"),
+        ERROR_CODE_REVOKE_TOKEN_BY_APP_ID("10006", "Error revoking issued tokens", "A system " +
+                "error occurred while revoking issued tokens for application: %s"),
+        ERROR_CODE_INVALID_INBOUND_PROTOCOL("10007", "Inbound protocol not found.", "Inbound " +
+                "protocol cannot be found for the provided app id: %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/impl/ApplicationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/impl/ApplicationsApiServiceImpl.java
@@ -1,0 +1,39 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.ApplicationsApiService;
+import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.core.AuthorizedAppsService;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation of {@link ApplicationsApiService}
+ */
+public class ApplicationsApiServiceImpl implements ApplicationsApiService {
+
+    @Autowired
+    private AuthorizedAppsService authorizedAppsService;
+
+    @Override
+    public Response deleteIssuedTokensByAppId(String applicationId) {
+
+        authorizedAppsService.deleteIssuedTokensByAppId(applicationId);
+        return Response.noContent().build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/resources/META-INF/cxf/authorized-apps-user-v2-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/resources/META-INF/cxf/authorized-apps-user-v2-cxf.xml
@@ -19,4 +19,5 @@
     <bean class="org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.core.AuthorizedAppsService"/>
     <bean class="org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl.UserIdApiServiceImpl"/>
     <bean class="org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl.MeApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl.ApplicationsApiServiceImpl"/>
 </beans>

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/resources/authorizedApps.yaml
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/resources/authorizedApps.yaml
@@ -233,6 +233,28 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  '/applications/{application-id}/tokens':
+    delete:
+      tags:
+        - admin
+      summary: "Removes all the tokens granted for an application"
+      operationId: deleteIssuedTokensByAppId
+      description: |
+        Removes all the tokens granted for a given app ID
+      parameters:
+        - $ref: '#/components/parameters/applicationNamePathParam'
+      responses:
+        '204':
+          $ref: '#/components/responses/Deleted'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
 components:
   parameters:
     usernamePathParams:

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>
-        <identity.oauth.version>6.4.150</identity.oauth.version>
+        <identity.oauth.version>6.6.34-SNAPSHOT</identity.oauth.version>
         <testng.version>6.9.10</testng.version>
         <fido2.version>5.1.17</fido2.version>
         <identity.totp.version>2.1.4</identity.totp.version>


### PR DESCRIPTION
## Purpose
> Currently there is no API to revoke all the tokens issued for a given application via a single API call.
OAuth2 Authorized Apps API V2[1] has APIs for the bellow combinations.
>- Per user per application
>- Per user all the applications

## Goals
>  introduce a new delete API into the OAuth2 Authorized Apps API V2[1] .

## GIT Issue
>https://github.com/wso2/product-is/issues/11993

## Related PRs
> wso2-extensions : identity-inbound-auth-oauth : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1627

[1]- https://is.docs.wso2.com/en/latest/develop/authorized-apps-v2-rest-api/#/admin