### PR TITLE
Session Delete Improvements

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Constants.java
@@ -60,7 +60,7 @@ public class Constants {
                 "Server Encountered an error while retrieving the user."),
         INVALID_TENANT_DOMAIN(USER_MANAGEMENT_PREFIX.getPrefix() + "10002",
                 "Invalid tenant domain.",
-                "Server Encountered an error while retrieving tenantId for tenantDomain.");
+                "Server Encountered an error while retrieving tenantId for tenantDomain: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Constants.java
@@ -57,7 +57,10 @@ public class Constants {
                 "The provided userId is invalid."),
         ERROR_CODE_SERVER_ERROR(USER_MANAGEMENT_PREFIX.getPrefix() + "15001",
                 "Unable to retrieve User.",
-                "Server Encountered an error while retrieving the user.");
+                "Server Encountered an error while retrieving the user."),
+        INVALID_TENANT_DOMAIN(USER_MANAGEMENT_PREFIX.getPrefix() + "10002",
+                "Invalid tenant domain.",
+                "Server Encountered an error while retrieving tenantId for tenantDomain.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
@@ -37,8 +37,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.user.common.Constants.CORRELATION_ID_MDC;
-import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.*;
+import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.INVALID_TENANT_DOMAIN;
+import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.ERROR_CODE_SERVER_ERROR;
 
 /**
  * Common util class
@@ -146,10 +147,10 @@ public class Util {
     /**
      * Validate whether the given filter is not empty and tenantDomain is valid.
      *
-     * @param filter    filter to be applied for session termination
-     * @param tenantDomain  tenant domain of the requester
+     * @param filter        Filter to be applied for session termination.
+     * @param tenantDomain  Tenant domain of the requester.
      */
-    public static void  validateFilter(String filter, String tenantDomain) {
+    public static void validateFilter(String filter, String tenantDomain) {
 
         if (StringUtils.isEmpty(filter)) {
             throw new WebApplicationException("Filter is empty.");

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/Util.java
@@ -162,7 +162,7 @@ public class Util {
             throw new APIError(Response.Status.BAD_REQUEST, new ErrorResponse.Builder()
                     .withCode(INVALID_TENANT_DOMAIN.getCode())
                     .withMessage(INVALID_TENANT_DOMAIN.getMessage())
-                    .withDescription(INVALID_TENANT_DOMAIN.getDescription())
+                    .withDescription(String.format(INVALID_TENANT_DOMAIN.getDescription(), tenantDomain))
                     .build(log, e, "Error occurred while retrieving tenantId for tenantDomain: " + tenantDomain));
         }
     }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApi.java
@@ -25,7 +25,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SearchResponseDTO;
 
 import javax.validation.Valid;
-import javax.ws.rs.*;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 @Path("/sessions")

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApi.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApi.java
@@ -25,10 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SearchResponseDTO;
 
 import javax.validation.Valid;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 @Path("/sessions")
@@ -58,4 +55,22 @@ public class SessionsApi {
         return delegate.getSessions(filter, limit, since, until);
     }
 
+    @Valid
+    @DELETE
+    @ApiOperation(value = "Terminates the sessions selected based on a filtering criteria",
+            notes = "Terminates a number of sessions selected based on a provided filtering criteria.\n<b>Permission required:</b>\n * /permission/admin/login\n",
+            response = void.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "No Content"),
+            @ApiResponse(code = 400, message = "Invalid input request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Resource Forbidden"),
+            @ApiResponse(code = 500, message = "Internal Server Error")})
+    public Response terminateFilteredSessions(@ApiParam(value = "Condition to filter the retrieval of records.\nThe filter parameter must contain at least one valid expression (for multiple expressions they must be combined using the 'and' logical operator).\nEach expression must contain an attribute name followed by an attribute operator and a value (attribute names, operators and values used in filters are case insensitive).\n\nThe operators supported in the expression are listed next\n| Operator | Description | Behavior |\n|----------|-------------|----------|\n| eq | equal | The attribute and operator values must be identical for a match. |\n| sw | starts with | The entire operator value must be a substring of the attribute value, starting at the beginning of the attribute value. |\n| ew | ends with | The entire operator value must be a substring of the attribute value, matching at the end of the attribute value. |\n| co | contains | The entire operator value must be a substring of the attribute value for a match. |\n| le | less than or equal to | If the attribute value is less than or equal to the operator value, there is a match. |\n| ge | greater than or equal to | If the attribute value is greater than or equal to the operator value, there is a match. |\n\nThe attributes supported in the expression are listed next\n| Name | Operators | Description |\n|------|-----------|-------------|\n| loginId | eq, sw, ew, co | Filter results by the login identifier of the user who owns the session. |\n| sessionId | eq, sw, ew, co | Filter results by the ID of the session. |\n| appName | eq, sw, ew, co | Filter results by the name of the application related to the session. |\n| ipAddress | eq | Filter results by the IP address of the session. |\n| userAgent | eq, sw, ew, co | Filter results by the user agent of the session. |\n| loginTime | le, ge | Filter results by the login time of the session. |\n| lastAccessTime | le, ge | Filter results by the last access time of the session. |\n\n_Example, filter=loginId eq john and userAgent co Chrome_\n") @QueryParam("filter") String filter,
+                                              @ApiParam(value = "Maximum number of records to return.\n_Default value: 20_\n") @QueryParam("limit") Integer limit,
+                                              @ApiParam(value = "Unix timestamp data value that points to the start of the range of data to be returned.\n_Note: As results are ordered by more recent first this will provide previous page of results._\n") @QueryParam("since") Long since,
+                                              @ApiParam(value = "Unix timestamp data value that points to the end of the range of data to be returned.\n_Note: As results are ordered by more recent first this will provide next page of results._\n") @QueryParam("until") Long until) {
+
+        return delegate.terminateFilteredSessions(filter, limit, since, until);
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/session/v1/SessionsApiService.java
@@ -22,4 +22,14 @@ public abstract class SessionsApiService {
 
     public abstract Response getSessions(String filter, Integer limit, Long since, Long until);
 
+    /**
+     * Terminates sessions selected based on filter.
+     *
+     * @param filter    the filter based on which the sessions to be terminated are selected (Mandatory)
+     * @param limit maximum number of sessions to be selected (Optional)
+     * @param since timestamp data value that points to the start of the range of data to be returned (Optional)
+     * @param until timestamp data value that points to the end of the range of data to be returned (Optional)
+     * @return Response
+     */
+    public abstract Response terminateFilteredSessions(String filter, Integer limit, Long since, Long until);
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -225,6 +225,30 @@ public class SessionManagementService {
     }
 
     /**
+     * Terminate active sessions based on a filter criteria.
+     *
+     * @param filter    the filter based on which the sessions to be terminated are selected (Mandatory)
+     * @param limit maximum number of sessions to be selected (Optional)
+     * @param since timestamp data value that points to the start of the range of data to be returned (Optional)
+     * @param until timestamp data value that points to the end of the range of data to be returned (Optional)
+     */
+    public void terminateFilteredSessions(String tenantDomain, String filter, Integer limit, Long since, Long until) {
+
+        try {
+            List<ExpressionNode> filterNodes = getExpressionNodes(filter, since, until);
+            validateSearchFilter(filterNodes);
+
+            limit = limit == null || limit <= 0 ? SESSIONS_SEARCH_DEFAULT_LIMIT : limit;
+            String sortOrder = since != null ? SessionMgtConstants.ASC : SessionMgtConstants.DESC;
+
+            SessionManagementServiceHolder.getUserSessionManagementService()
+                    .terminateFilteredSessions(tenantDomain, filterNodes, limit + 1, sortOrder);
+        } catch (SessionManagementException e) {
+            throw handleSessionManagementException(e);
+        }
+    }
+
+    /**
      * Terminate the session of the given session id.
      *
      * @param userId    unique id of the user

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -227,10 +227,10 @@ public class SessionManagementService {
     /**
      * Terminate active sessions based on a filter criteria.
      *
-     * @param filter    the filter based on which the sessions to be terminated are selected (Mandatory)
-     * @param limit maximum number of sessions to be selected (Optional)
-     * @param since timestamp data value that points to the start of the range of data to be returned (Optional)
-     * @param until timestamp data value that points to the end of the range of data to be returned (Optional)
+     * @param filter The filter based on which the sessions to be terminated are selected (Mandatory).
+     * @param limit  Maximum number of sessions to be selected (Optional).
+     * @param since  Timestamp data value that points to the start of the range of data to be returned (Optional).
+     * @param until  Timestamp data value that points to the end of the range of data to be returned (Optional).
      */
     public void terminateFilteredSessions(String tenantDomain, String filter, Integer limit, Long since, Long until) {
 

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/SessionsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/SessionsApiServiceImpl.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.api.user.common.ContextLoader;
+import org.wso2.carbon.identity.api.user.common.Util;
 import org.wso2.carbon.identity.rest.api.user.session.v1.SessionsApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SearchResponseDTO;
@@ -39,5 +40,13 @@ public class SessionsApiServiceImpl extends SessionsApiService {
                 filter, limit, since, until);
 
         return Response.ok().entity(responseDTO).build();
+    }
+
+    @Override
+    public Response terminateFilteredSessions(String filter, Integer limit, Long since, Long until) {
+
+        Util.validateFilter(filter, ContextLoader.getTenantDomainFromContext());
+        sessionManagementService.terminateFilteredSessions(ContextLoader.getTenantDomainFromContext(), filter, limit, since, until);
+        return Response.noContent().build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/resources/session.yaml
@@ -337,6 +337,35 @@ paths:
         500:
           $ref: '#/responses/ServerError'
 
+    delete:
+      tags:
+        - sysadmin
+      description: Terminates a number of sessions selected based on a provided filtering criteria. <br>
+        <b>Permission required:</b> <br>
+        * /permission/admin/manage/identity/authentication/session/delete <br>
+        <b>Scope required:</b> <br>
+        * internal_session_delete
+      summary: Terminates the sessions selected based on a filtering criteria
+      operationId: terminateFilteredSessions
+      parameters:
+        - $ref: '#/parameters/filterQueryParam'
+        - $ref: '#/parameters/limitQueryParam'
+        - $ref: '#/parameters/sinceQueryParam'
+        - $ref: '#/parameters/untilQueryParam'
+      produces:
+        - application/json
+      responses:
+        204:
+          $ref: '#/responses/NoContent'
+        400:
+          $ref: '#/responses/InvalidInput'
+        401:
+          $ref: '#/responses/Unauthorized'
+        403:
+          $ref: '#/responses/Forbidden'
+        500:
+          $ref: '#/responses/ServerError'
+
 #-----------------------------------------------------
 # Descriptions of common responses
 #-----------------------------------------------------


### PR DESCRIPTION
## Purpose
> Includes new features to the session management API along with wso2/carbon-identity-framework#3750.

## Goals
> Includes new features to the session management API:

- Terminate active sessions that fulfil the criteria determined by the filter parameter value.

## Approach
### Service Specification
> https://app.swaggerhub.com/apis/sessionapi/wso-2_identity_server_user_session_management_api_definition/v1

#### Sessions API
> Extended /sessions endpoint with delete implementation
Operation available for privileged users. Delete active sessions on the system retrieved based on. a filtering criteria.
Based off of wso2/identity-api-user#132

## User stories
> As a System Admin user, I want to terminate user sessions based on a criteria.

## Release note
> Session Management API enhancement.

## Documentation
> Impacts on [User's Session Management API Definition - v1](https://is.docs.wso2.com/en/5.10.0/develop/session-mgt-rest-api/)

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Sample Request
```
DELETE t/carbon.super/api/users/v1/sessions?filter=appName eq My Account
Host: localhost:9443
Authorization: Basic YWRtaW46YWRtaW4=
```

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/3750

## Migrations (if applicable)
> N/A

## Test environment
> OS: macOS Big Sur
JDK version: OpenJDK 1.8.0_292
Databases: Embedded H2
 
## Learning
> N/A