### PR TITLE
Enable session read/delete for federated users using me endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.common/src/main/java/org/wso2/carbon/identity/api/user/session/common/constant/SessionManagementConstants.java
@@ -42,7 +42,10 @@ public class SessionManagementConstants {
                 "Sorting capability is not supported in this version of the API."),
         ERROR_CODE_SESSION_TERMINATE_FORBIDDEN("10010",
                 "Action Forbidden",
-                "User is not authorized to terminate the session/s.");
+                "User is not authorized to terminate the session/s."),
+        ERROR_CODE_UNABLE_TO_RETRIEVE_FEDERATED_USERID("10011",
+                "Unable to retrieve federated userId",
+                "Error occurred while retrieving federated userId of the user: %s in the tenant domain: %s.");
 
         private final String code;
         private final String message;

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <identity.governance.version>1.4.28</identity.governance.version>
-        <carbon.identity.framework.version>5.18.164</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.273</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>


### PR DESCRIPTION
Related Issues: https://github.com/wso2/product-is/issues/12730
## Purpose
> Currently session reading and deletion using me endpoint does not work for federated users. So federated users cannot terminate their sessions and bonded tokens using the me endpoint. This fix is to enable session delete/terminate for federated users

## Approach
> Currently when invoking me endpoint, we are checking the userId of the user in userstores. But since federated users are stored in idn databases, We get the userid of federated users from the idn database. After the correct userId is provided, session read/delete work normally.
