### PR TITLE
Upgrade Jackson and CXF versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,10 +339,10 @@
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <jackson-jaxrs-json-provider.version>2.10.5</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.10.5.1</jackson-databind.version>
-        <jackson-dataformat-xml.version>2.10.5</jackson-dataformat-xml.version>
-        <cxf-bundle.version>3.3.7</cxf-bundle.version>
+        <jackson-jaxrs-json-provider.version>2.13.0</jackson-jaxrs-json-provider.version>
+        <jackson-databind.version>2.13.0</jackson-databind.version>
+        <jackson-dataformat-xml.version>2.13.0</jackson-dataformat-xml.version>
+        <cxf-bundle.version>3.4.5</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>
         <spring-web.version>5.1.1.RELEASE</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>


### PR DESCRIPTION
## Purpose
Upgraded Jackson version to 2.13.0 and CXF version to 3.4.5 to mitigate the known vulnerabilities.