### PR TITLE
Stop printing error logs for client exceptions in user account association flow and make it debug logs

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/core/UserAssociationService.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/core/UserAssociationService.java
@@ -200,14 +200,14 @@ public class UserAssociationService {
 
     private APIError handleUserAccountAssociationException(UserAccountAssociationException e, String message) {
 
-        ErrorResponse errorResponse = new ErrorResponse.Builder()
-                .withCode(e.getErrorCode())
-                .withMessage(message)
-                .build(log, e, e.getMessage());
-
         Response.Status status;
+        ErrorResponse errorResponse;
 
         if (e instanceof UserAccountAssociationClientException) {
+            errorResponse = new ErrorResponse.Builder()
+                    .withCode(e.getErrorCode())
+                    .withMessage(message)
+                    .build(log, e.getMessage());
             if (e.getErrorCode() != null) {
                 String errorCode = e.getErrorCode();
                 errorCode = errorCode.contains(ERROR_CODE_DELIMITER) ? errorCode : ASSOCIATION_ERROR_PREFIX
@@ -217,6 +217,10 @@ public class UserAssociationService {
             handleErrorDescription(e, errorResponse);
             status = Response.Status.BAD_REQUEST;
         } else {
+            errorResponse = new ErrorResponse.Builder()
+                    .withCode(e.getErrorCode())
+                    .withMessage(message)
+                    .build(log, e, e.getMessage());
             status = Response.Status.INTERNAL_SERVER_ERROR;
         }
         return new APIError(status, errorResponse);


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/13382.
We should not log the errors for client exceptions. 
Before the fix:
We were logging error with exception for client exceptions too.
```
[2022-04-28 10:37:58,489] [c13adb48-6cc7-4386-b938-4b2620443168] ERROR {org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService} - errorCode: 8526 | message: 8526 - The user name or password you entered is incorrect org.wso2.carbon.identity.user.account.association.exception.UserAccountAssociationClientException: 8526 - The user name or password you entered is incorrect
	at org.wso2.carbon.identity.user.account.association.UserAccountConnectorImpl.handleUserAccountAssociationClientException(UserAccountConnectorImpl.java:500)
	at org.wso2.carbon.identity.user.account.association.UserAccountConnectorImpl.createUserAccountAssociation(UserAccountConnectorImpl.java:252)
	at org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService.createUserAccountAssociation(UserAssociationService.java:85)
	at org.wso2.carbon.identity.rest.api.user.association.v1.impl.MeApiServiceImpl.meAssociationsPost(MeApiServiceImpl.java:54)
	at org.wso2.carbon.identity.rest.api.user.association.v1.MeApi.meAssociationsPost(MeApi.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96)
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:201)
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:104)
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59)
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121)
	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:265)
	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160)
	at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:225)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:304)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:217)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:681)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:279)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)

```
After the fix:
```
[2022-04-28 12:42:49,941] [5c29afaa-7f9e-4c20-aef2-d91e24a07a02] DEBUG {org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService} - errorCode: 8526 | message: 8526 - The user name or password you entered is incorrect
```

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.