### PR TITLE
Update maven-compiler-plugin version and set parameters to true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,12 +325,13 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>${maven.compiler.plugin.version}</version>
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>
@@ -342,7 +343,7 @@
 
     <properties>
         <!--Maven Plugin Version-->
-        <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <jackson-jaxrs-json-provider.version>2.13.2</jackson-jaxrs-json-provider.version>
         <jackson-databind.version>2.13.2.2</jackson-databind.version>


### PR DESCRIPTION
## Purpose
This PR will
- update the maven-compiler-plugin version to the latest (3.10.1)
- Set the <parameters> configuration of maven-compiler-plugin to true

## Related Issues
https://github.com/wso2/product-is/issues/14129

## Related PRs
https://github.com/wso2/identity-api-server/pull/375

## How to test
In MyAccount, go to `Security > Additional Authentication > Authenticator App`.
Click on the `+` sign to add an Authenticator app.
With this fix, the following WARN log should **not** be generated.
```
[2022-07-11 15:37:45,880] [4ddac944-b65d-4a96-938f-c6ea08a25db4]  WARN {org.hibernate.validator.internal.properties.javabean.JavaBeanExecutable} - HV000254: Missing parameter metadata for ActionEnum(String, int), which declares implicit or synthetic parameters. Automatic resolution of generic type information for method parameters may yield incorrect results if multiple parameters have the same erasure. To solve this, compile your code with the '-parameters' flag.
```