### PR TITLE
Use authenticator name when validating backup code feature related authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.mfa/org.wso2.carbon.identity.api.user.mfa.common/src/main/java/org/wso2/carbon/identity/api/user/mfa/common/MFAConstants.java
+++ b/components/org.wso2.carbon.identity.api.user.mfa/org.wso2.carbon.identity.api.user.mfa.common/src/main/java/org/wso2/carbon/identity/api/user/mfa/common/MFAConstants.java
@@ -26,8 +26,8 @@ public class MFAConstants {
 
     public static final String AUTHENTICATED_WITH_BASIC_AUTH = "AuthenticatedWithBasicAuth";
 
-    public static final String BACKUP_CODE_AUTHENTICATOR = "Backup Code Authenticator";
-    public static final String TOTP_AUTHENTICATOR = "TOTP";
+    public static final String BACKUP_CODE_AUTHENTICATOR = "backup-code-authenticator";
+    public static final String TOTP_AUTHENTICATOR = "totp";
 
     /**
      * Enum for MFA related errors in the format of


### PR DESCRIPTION
### Purpose
With the fix for https://github.com/wso2/product-is/issues/14843, we'll be introducing a new parameter to resolve the authenticator identifier in `authenticationOptions`. For backup code feature, ideally we should use authenticator name to resolve the `authenticationOptions` in mfa flow.

Details: https://github.com/wso2/product-is/issues/14843#issuecomment-1236530106

### Related Issues
- https://github.com/wso2/product-is/issues/14844

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.