### PR TITLE
Validate totp secret key before storing

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.totp/org.wso2.carbon.identity.api.user.totp.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/totp/v1/core/TOTPService.java
+++ b/components/org.wso2.carbon.identity.api.user.totp/org.wso2.carbon.identity.api.user.totp.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/totp/v1/core/TOTPService.java
@@ -130,7 +130,8 @@ public class TOTPService {
         TOTPResponseDTO totpResponseDTO = new TOTPResponseDTO();
         User user = getUser();
         try {
-            Map<String, String> claims = TOTPKeyGenerator.generateClaims(user.toFullQualifiedUsername(), false);
+            Map<String, String> claims = TOTPKeyGenerator.
+                    generateClaimsWithVerifySecretKey(user.toFullQualifiedUsername(), false);
             totpResponseDTO.setQrCodeUrl(TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims,
                     user.toFullQualifiedUsername()));
             return totpResponseDTO;
@@ -197,7 +198,8 @@ public class TOTPService {
         TOTPResponseDTO totpResponseDTO = new TOTPResponseDTO();
         User user = getUser();
         try {
-            Map<String, String> claims = TOTPKeyGenerator.generateClaims(user.toFullQualifiedUsername(), true);
+            Map<String, String> claims = TOTPKeyGenerator.
+                    generateClaimsWithVerifySecretKey(user.toFullQualifiedUsername(), true);
             totpResponseDTO.setQrCodeUrl(TOTPKeyGenerator.addTOTPClaimsAndRetrievingQRCodeURL(claims,
                     user.toFullQualifiedUsername()));
         } catch (TOTPException e) {
@@ -229,11 +231,11 @@ public class TOTPService {
                             .setKeyRepresentation(encoding);
             TOTPAuthenticatorCredentials totpAuthenticator =
                     new TOTPAuthenticatorCredentials(configBuilder.build());
-            String secretKey = getSecretKey().getSecret();
             if (log.isDebugEnabled()) {
                 log.debug("Validating TOTP verification code for the user: " + username);
             }
-            totpResponseDTO.setIsValid(totpAuthenticator.authorize(secretKey, verificationCode));
+            totpResponseDTO.setIsValid(totpAuthenticator.
+                    authorizeAndStoreSecret(verificationCode, username));
         } catch (AuthenticationFailedException e) {
             throw handleException(e, USER_ERROR_UNAUTHORIZED_USER);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <identity.oauth.version>6.7.71</identity.oauth.version>
         <testng.version>6.9.10</testng.version>
         <fido2.version>5.1.17</fido2.version>
-        <identity.totp.version>2.1.4</identity.totp.version>
+        <identity.totp.version>3.3.1</identity.totp.version>
         <identity.backup.code.version>0.0.4</identity.backup.code.version>
         <lombok.version>1.18.20</lombok.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
Resolves: https://github.com/wso2/product-is/issues/15197

With this fix, "http://wso2.org/claims/identity/verifySecretkey" claim will be used to store the secret key temporarily before validating it. After the secret key is validated it will move to "http://wso2.org/claims/identity/secretkey".

Related PR: https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/147