### PR TITLE
Handle client exception when API is disabled

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
@@ -555,6 +555,10 @@ public class RecoveryUtil {
         clientErrorMap.put(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_VERIFIED_CHANNELS_FOR_USER.getCode(),
                 REQUEST_NOT_FOUND_ERROR_CATEGORY);
 
+        // API disabled error.
+        clientErrorMap.put(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_API_DISABLED.getCode(),
+                REQUEST_NOT_FOUND_ERROR_CATEGORY);
+
         // Invalid recovery codes errors.
         clientErrorMap.put(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_CODE.getCode(),
                 REQUEST_NOT_ACCEPTABLE_ERROR_CATEGORY);

--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
-        <identity.governance.version>1.8.71</identity.governance.version>
+        <identity.governance.version>1.8.73</identity.governance.version>
         <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>


### PR DESCRIPTION
## Purpose
Due to the encountered issues with the current V1 API, a new V2 API is provided. Hence, current recovery service will be disabled. There will be a config to enable/disable the service. This PR handles the client exception when the recovery service is disabled.

Related issue: https://github.com/wso2/product-is/issues/16536

### When should this PR be merged
This should be merged after https://github.com/wso2-extensions/identity-governance/pull/766
Governance version: v1.8.73