### PR TITLE
Improve tenant resolving with tenant qualified URL enabled

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/application/v1/core/ApplicationService.java
+++ b/components/org.wso2.carbon.identity.api.user.application/org.wso2.carbon.identity.rest.api.user.application.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/application/v1/core/ApplicationService.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
 import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.application.v1.core.function.ApplicationBasicInfoToApiModel;
 import org.wso2.carbon.identity.rest.api.user.application.v1.model.ApplicationListResponse;
 import org.wso2.carbon.identity.rest.api.user.application.v1.model.ApplicationResponse;
@@ -71,7 +72,7 @@ public class ApplicationService {
 
         try {
 
-            String tenantDomain = ContextLoader.getTenantDomainFromContext();
+            String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
             ApplicationBasicInfo applicationBasicInfo = ApplicationServiceHolder.getDiscoverableApplicationManager()
                     .getDiscoverableApplicationBasicInfoByResourceId(applicationId, tenantDomain);
             if (applicationBasicInfo == null) {
@@ -104,7 +105,7 @@ public class ApplicationService {
 
         handleNotImplementedCapabilities(attributes, sortOrder, sortBy);
 
-        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         String filterFormatted = buildFilter(filter);
         try {
             List<ApplicationBasicInfo> applicationBasicInfos = ApplicationServiceHolder

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/MeApiServiceImpl.java
@@ -2,9 +2,9 @@ package org.wso2.carbon.identity.rest.api.user.association.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.function.UniqueIdToUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.association.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.dto.AssociationUserRequestDTO;
@@ -86,7 +86,7 @@ public class MeApiServiceImpl extends MeApiService {
     private String getFullyQualifiedUserName(String userId) {
 
         User user = new UniqueIdToUser().apply(UserAssociationServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
         return user.toFullQualifiedUsername();
     }
 

--- a/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.association/org.wso2.carbon.identity.api.user.association.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/association/v1/impl/UserIdApiServiceImpl.java
@@ -1,9 +1,9 @@
 package org.wso2.carbon.identity.rest.api.user.association.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.function.UniqueIdToUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.association.v1.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.core.UserAssociationService;
 import org.wso2.carbon.identity.rest.api.user.association.v1.util.UserAssociationServiceHolder;
@@ -34,7 +34,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     private String getUser(String userId) {
 
         User user = new UniqueIdToUser().apply(UserAssociationServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
         return user.toFullQualifiedUsername();
     }
 

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v1/impl/UserIdApiServiceImpl.java
@@ -18,9 +18,9 @@ package org.wso2.carbon.identity.rest.api.user.authorized.apps.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.function.UniqueIdToUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v1.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v1.core.AuthorizedAppsService;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v1.dto.AuthorizedAppDTO;
@@ -74,6 +74,6 @@ public class UserIdApiServiceImpl extends UserIdApiService {
 
     private User getUser(String userId) {
 
-        return new UniqueIdToUser().apply(realmService, userId, ContextLoader.getTenantDomainFromContext());
+        return new UniqueIdToUser().apply(realmService, userId, IdentityTenantUtil.resolveTenantDomain());
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/core/AuthorizedAppsService.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/core/AuthorizedAppsService.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.error.APIError;
 import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.user.common.function.UserToUniqueId;
@@ -234,7 +233,7 @@ public class AuthorizedAppsService {
      */
     public void deleteIssuedTokensByAppId(String applicationId) {
 
-        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         ServiceProvider application = getServiceProvider(applicationId, tenantDomain);
 
         // Extract the inbound authentication request config for the given inbound type.

--- a/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.authorized.apps/org.wso2.carbon.identity.rest.api.user.authorized.apps.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/authorized/apps/v2/impl/UserIdApiServiceImpl.java
@@ -18,9 +18,9 @@ package org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.function.UniqueIdToUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.core.AuthorizedAppsService;
 import org.wso2.carbon.identity.rest.api.user.authorized.apps.v2.dto.AuthorizedAppDTO;
@@ -75,6 +75,6 @@ public class UserIdApiServiceImpl implements UserIdApiService {
 
     private User getUser(String userId) {
 
-        return new UniqueIdToUser().apply(realmService, userId, ContextLoader.getTenantDomainFromContext());
+        return new UniqueIdToUser().apply(realmService, userId, IdentityTenantUtil.resolveTenantDomain());
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.challenge/org.wso2.carbon.identity.rest.api.user.challenge.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/challenge/v1/core/UserChallengeService.java
+++ b/components/org.wso2.carbon.identity.api.user.challenge/org.wso2.carbon.identity.rest.api.user.challenge.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/challenge/v1/core/UserChallengeService.java
@@ -21,10 +21,10 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.user.challenge.common.ChallengeQuestionServiceHolder;
 import org.wso2.carbon.identity.api.user.challenge.common.Constant;
 import org.wso2.carbon.identity.api.user.common.Constants;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.error.APIError;
 import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.model.ChallengeQuestion;
@@ -65,7 +65,7 @@ public class UserChallengeService {
 
         try {
             return buildChallengesDTO(ChallengeQuestionServiceHolder.getChallengeQuestionManager()
-                    .getAllChallengeQuestionsForUser(ContextLoader.getTenantDomainFromContext(), user), offset, limit);
+                    .getAllChallengeQuestionsForUser(IdentityTenantUtil.resolveTenantDomain(), user), offset, limit);
         } catch (IdentityRecoveryException e) {
             throw handleIdentityRecoveryException(e,
                     Constant.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_CHALLENGES_FOR_USER);

--- a/components/org.wso2.carbon.identity.api.user.challenge/org.wso2.carbon.identity.rest.api.user.challenge.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/challenge/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.challenge/org.wso2.carbon.identity.rest.api.user.challenge.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/challenge/v1/impl/UserIdApiServiceImpl.java
@@ -20,9 +20,9 @@ package org.wso2.carbon.identity.rest.api.user.challenge.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.api.user.challenge.common.ChallengeQuestionServiceHolder;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.function.UniqueIdToUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.challenge.v1.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService;
 import org.wso2.carbon.identity.rest.api.user.challenge.v1.dto.ChallengeAnswerDTO;
@@ -108,6 +108,6 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     private User getUser(String userId) {
 
         return new UniqueIdToUser().apply(ChallengeQuestionServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.identity.api.user.common;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.api.user.common.error.APIError;
@@ -28,7 +27,6 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
@@ -40,7 +38,6 @@ import javax.ws.rs.core.Response;
 import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.api.user.common.Constants.ErrorMessage.ERROR_CODE_SERVER_ERROR;
 import static org.wso2.carbon.identity.api.user.common.Constants.TENANT_CONTEXT_PATH_COMPONENT;
-import static org.wso2.carbon.identity.api.user.common.Constants.TENANT_NAME_FROM_CONTEXT;
 import static org.wso2.carbon.identity.api.user.common.Constants.USER_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.UNEXPECTED_SERVER_ERROR;
 
@@ -57,11 +54,7 @@ public class ContextLoader {
      */
     public static String getTenantDomainFromContext() {
 
-        String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        if (IdentityUtil.threadLocalProperties.get().get(TENANT_NAME_FROM_CONTEXT) != null) {
-            tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(TENANT_NAME_FROM_CONTEXT);
-        }
-        return tenantDomain;
+        return IdentityTenantUtil.resolveTenantDomain();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.idv/org.wso2.carbon.identity.api.user.idv.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/idv/v1/core/IdentityVerificationService.java
+++ b/components/org.wso2.carbon.identity.api.user.idv/org.wso2.carbon.identity.api.user.idv.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/idv/v1/core/IdentityVerificationService.java
@@ -27,7 +27,6 @@ import org.wso2.carbon.extension.identity.verification.mgt.model.IdVClaim;
 import org.wso2.carbon.extension.identity.verification.mgt.model.IdVProperty;
 import org.wso2.carbon.extension.identity.verification.mgt.model.IdentityVerifierData;
 import org.wso2.carbon.extension.identity.verification.mgt.utils.IdentityVerificationConstants;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.error.APIError;
 import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.user.idv.common.Constants;
@@ -415,7 +414,7 @@ public class IdentityVerificationService {
 
     private int getTenantId() {
 
-        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         if (StringUtils.isBlank(tenantDomain)) {
             throw handleException(
                     Response.Status.INTERNAL_SERVER_ERROR,

--- a/components/org.wso2.carbon.identity.api.user.mfa/org.wso2.carbon.identity.api.user.mfa.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/mfa/v1/core/MFAService.java
+++ b/components/org.wso2.carbon.identity.api.user.mfa/org.wso2.carbon.identity.api.user.mfa.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/mfa/v1/core/MFAService.java
@@ -148,7 +148,7 @@ public class MFAService {
 
     private String getTenantDomain() {
 
-        return ContextLoader.getTenantDomainFromContext();
+        return IdentityTenantUtil.resolveTenantDomain();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/SessionsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/SessionsApiServiceImpl.java
@@ -17,7 +17,7 @@
 package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.session.v1.SessionsApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SearchResponseDTO;
@@ -35,7 +35,7 @@ public class SessionsApiServiceImpl extends SessionsApiService {
     @Override
     public Response getSessions(String filter, Integer limit, Long since, Long until) {
 
-        SearchResponseDTO responseDTO = sessionManagementService.getSessions(ContextLoader.getTenantDomainFromContext(),
+        SearchResponseDTO responseDTO = sessionManagementService.getSessions(IdentityTenantUtil.resolveTenantDomain(),
                 filter, limit, since, until);
 
         return Response.ok().entity(responseDTO).build();

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
@@ -23,9 +23,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.context.CarbonContext;
-import org.wso2.carbon.identity.api.user.common.ContextLoader;
 import org.wso2.carbon.identity.api.user.common.Util;
 import org.wso2.carbon.identity.api.user.session.common.util.SessionManagementServiceHolder;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionDTO;
@@ -52,7 +52,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     public Response getSessionBySessionId(String userId, String sessionId) {
 
         Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
 
         Optional<SessionDTO> session = sessionManagementService.getSessionBySessionId(userId, sessionId);
         if (session.isPresent()) {
@@ -66,7 +66,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     public Response getSessionsByUserId(String userId, Integer limit, Integer offset, String filter, String sort) {
 
         Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
 
         SessionsDTO sessionsOfUser = sessionManagementService.getSessionsByUserId(userId, limit, offset, filter, sort);
         if (sessionsOfUser == null || sessionsOfUser.getSessions().isEmpty()) {
@@ -80,7 +80,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
     public Response terminateSessionBySessionId(String userId, String sessionId) {
 
         Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
-                ContextLoader.getTenantDomainFromContext());
+                IdentityTenantUtil.resolveTenantDomain());
         sessionManagementService.terminateSessionBySessionId(userId, sessionId);
         return Response.noContent().build();
     }
@@ -112,7 +112,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
             }
 
             Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
-                    ContextLoader.getTenantDomainFromContext());
+                    IdentityTenantUtil.resolveTenantDomain());
             sessionManagementService.terminateSessionsByUserId(userId);
             return Response.noContent().build();
         } catch (UserStoreException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <identity.governance.version>1.8.73</identity.governance.version>
-        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.380</carbon.identity.framework.version>
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <carbon.business-process.version>4.5.2</carbon.business-process.version>


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/16906

Improve resolving tenant domain when tenant qualified URL feature is enabled. If the tenant domain is available in the context retrieve it otherwise retrieve tenant domain from the privileged carbon context.