### PR TITLE
Improve get user authorized organization endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/pom.xml
@@ -44,5 +44,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/src/main/java/org/wso2/carbon/identity/api/user/organization/common/UserOrganizationServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/src/main/java/org/wso2/carbon/identity/api/user/organization/common/UserOrganizationServiceHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.user.organization.common;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 
@@ -29,6 +30,7 @@ public class UserOrganizationServiceHolder {
     private static OrganizationUserResidentResolverService organizationUserResidentResolverService;
 
     private static OrganizationManager organizationManagementService;
+    private static ApplicationManagementService applicationManagementService;
 
     /**
      * Method to get the organization user resident resolver OSGi service.
@@ -70,5 +72,26 @@ public class UserOrganizationServiceHolder {
             OrganizationManager organizationManagementService) {
 
         UserOrganizationServiceHolder.organizationManagementService = organizationManagementService;
+    }
+
+    /**
+     * Get application management service.
+     *
+     * @return Application management service.
+     */
+    public static ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Set application management OSGi service.
+     *
+     * @param applicationManagementService Application management service.
+     */
+    public static void setApplicationManagementService(
+            ApplicationManagementService applicationManagementService) {
+
+        UserOrganizationServiceHolder.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/src/main/java/org/wso2/carbon/identity/api/user/organization/common/factory/ApplicationManagementOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.api.user.organization.common/src/main/java/org/wso2/carbon/identity/api/user/organization/common/factory/ApplicationManagementOSGIServiceFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.user.organization.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the ApplicationManagementService type of object inside the container.
+ */
+public class ApplicationManagementOSGIServiceFactory extends AbstractFactoryBean<ApplicationManagementService> {
+
+    private ApplicationManagementService applicationManagementService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected ApplicationManagementService createInstance() throws Exception {
+
+        if (this.applicationManagementService == null) {
+            ApplicationManagementService service = (ApplicationManagementService) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(ApplicationManagementService.class, null);
+            if (service != null) {
+                this.applicationManagementService = service;
+            } else {
+                throw new Exception("Unable to retrieve Application Management service.");
+            }
+        }
+        return this.applicationManagementService;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/pom.xml
@@ -102,6 +102,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/organization/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/organization/v1/MeApi.java
@@ -62,9 +62,9 @@ public class MeApi  {
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
     })
-    public Response rootGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen.", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
+    public Response rootGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen.", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive,     @Valid@ApiParam(value = "Retrieves the organizations that are authorized for the user through the role bound to the application.")  @QueryParam("authorizedAppName") String authorizedAppName) {
 
-        return delegate.rootGet(filter,  limit,  after,  before,  recursive );
+        return delegate.rootGet(filter,  limit,  after,  before,  recursive,  authorizedAppName );
     }
 
 }

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/organization/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/organization/v1/MeApiService.java
@@ -31,5 +31,5 @@ import javax.ws.rs.core.Response;
 
 public interface MeApiService {
 
-      public Response rootGet(String filter, Integer limit, String after, String before, Boolean recursive);
+      public Response rootGet(String filter, Integer limit, String after, String before, Boolean recursive, String authorizedAppName);
 }

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/organization/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/organization/v1/impl/MeApiServiceImpl.java
@@ -33,9 +33,10 @@ public class MeApiServiceImpl implements MeApiService {
     UserOrganizationService userOrganizationService;
 
     @Override
-    public Response rootGet(String filter, Integer limit, String after, String before, Boolean recursive) {
+    public Response rootGet(String filter, Integer limit, String after, String before, Boolean recursive,
+                            String authorizedAppName) {
 
         return Response.ok(userOrganizationService.getAuthorizedOrganizations(filter, limit, after, before,
-                recursive)).build();
+                recursive, authorizedAppName)).build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/resources/META-INF/cxf/user-organization-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/resources/META-INF/cxf/user-organization-v1-cxf.xml
@@ -27,9 +27,12 @@
           class="org.wso2.carbon.identity.api.user.organization.common.factory.OrganizationUserResidentResolverOSGIServiceFactory"/>
     <bean id="OrganizationMgtServiceFactoryBean"
           class="org.wso2.carbon.identity.api.user.organization.common.factory.OrganizationManagementOSGIServiceFactory"/>
+    <bean id="ApplicationManagementServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.user.organization.common.factory.ApplicationManagementOSGIServiceFactory"/>
     <bean id="UserOrganizationManagementServiceHolderBean"
           class="org.wso2.carbon.identity.api.user.organization.common.UserOrganizationServiceHolder">
         <property name="organizationUserResidentResolverService" ref="OrganizationUserResidentResolverServiceFactoryBean"/>
         <property name="organizationManagementService" ref="OrganizationMgtServiceFactoryBean"/>
+        <property name="applicationManagementService" ref="ApplicationManagementServiceFactoryBean"/>
     </bean>
 </beans>

--- a/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/resources/user.organization.yaml
+++ b/components/org.wso2.carbon.identity.api.user.organization/org.wso2.carbon.identity.rest.api.user.organization.v1/src/main/resources/user.organization.yaml
@@ -39,6 +39,7 @@ paths:
         - $ref: '#/components/parameters/afterQueryParam'
         - $ref: '#/components/parameters/beforeQueryParam'
         - $ref: '#/components/parameters/recursiveQueryParam'
+        - $ref: '#/components/parameters/authorizedAppNameQueryParam'
       responses:
         '200':
           description: Successful response
@@ -163,6 +164,14 @@ components:
       schema:
         type: boolean
         default: false
+    authorizedAppNameQueryParam:
+        in: query
+        name: authorizedAppName
+        required: false
+        description:
+          Retrieves the organizations that are authorized for the user through the role bound to the application.
+        schema:
+            type: string
   schemas:
     RootOrganizationResponse:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.config.mapper</groupId>
                 <artifactId>config-mapper</artifactId>
                 <version>${config.mapper.version}</version>
@@ -448,7 +454,7 @@
         <carbon.identity.account.association.version>5.3.7</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.oauth.version>6.7.71</identity.oauth.version>
-        <identity.org.mgt.core.version>1.0.85</identity.org.mgt.core.version>
+        <identity.org.mgt.core.version>1.0.97</identity.org.mgt.core.version>
         <testng.version>6.9.10</testng.version>
         <fido2.version>5.1.17</fido2.version>
         <identity.totp.version>3.3.1</identity.totp.version>


### PR DESCRIPTION
## Purpose
- Improve get user authorized organization endpoint

## Approach
- At the moment, we identify a given organization is an authorized organization if a user association with the authenticated user for that given organization exist. We can improve that logic further to check the associated user has a role associated with him to indicate it is an authorized organization.

## Related Issue
- https://github.com/wso2/product-is/issues/18727

##  Merge After
- https://github.com/wso2/identity-organization-management-core/pull/123