### PR TITLE
Resolve tenant domain from PrivilegedCarbonContext

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.v1/src/main/java/org/wso2/carbon/identity/api/user/onboard/v1/service/OfflineInviteLinkService.java
+++ b/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.v1/src/main/java/org/wso2/carbon/identity/api/user/onboard/v1/service/OfflineInviteLinkService.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.identity.api.user.onboard.common.error.APIError;
 import org.wso2.carbon.identity.api.user.onboard.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.user.onboard.common.util.Constants;
 import org.wso2.carbon.identity.api.user.onboard.v1.model.InvitationRequest;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;

--- a/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.v1/src/main/java/org/wso2/carbon/identity/api/user/onboard/v1/service/OfflineInviteLinkService.java
+++ b/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.v1/src/main/java/org/wso2/carbon/identity/api/user/onboard/v1/service/OfflineInviteLinkService.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.api.user.onboard.common.error.APIError;
 import org.wso2.carbon.identity.api.user.onboard.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.user.onboard.common.util.Constants;
@@ -67,7 +68,7 @@ public class OfflineInviteLinkService {
      */
     public String generatePasswordURL(InvitationRequest invitationRequest) {
 
-        String tenantDomain = getTenantDomainFromAuthUser();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         Configuration configuration = prepareConfigObject(invitationRequest, tenantDomain);
         try {
             return getUserOnboardCoreService().generatePasswordResetLink(configuration);
@@ -75,15 +76,6 @@ public class OfflineInviteLinkService {
             throw handleException(e, Constants.ErrorMessages.ERROR_UNABLE_TO_GENERATE_INVITE_LINK,
                     invitationRequest.getUsername());
         }
-    }
-
-    private String getTenantDomainFromAuthUser() {
-
-        String tenantDomain = null;
-        if (IdentityUtil.threadLocalProperties.get().get(AUTH_USER_TENANT_DOMAIN) != null) {
-            tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(AUTH_USER_TENANT_DOMAIN);
-        }
-        return tenantDomain;
     }
 
     private Configuration prepareConfigObject(InvitationRequest invitationRequest, String tenantDomain) {


### PR DESCRIPTION
Resolve the tenant domain from the PrivilegedCarbonContext rather than the auth_user since the auth user is a shadow account of a root org user for subOrgs.

Issue : https://github.com/wso2/product-is/issues/18788