### PR TITLE
Fix issue with logging client errors in offline invite link flow

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.common/src/main/java/org/wso2/carbon/identity/api/user/onboard/common/error/ErrorResponse.java
+++ b/components/org.wso2.carbon.identity.api.user.onboard/org.wso2.carbon.identity.api.user.onboard.common/src/main/java/org/wso2/carbon/identity/api/user/onboard/common/error/ErrorResponse.java
@@ -112,7 +112,7 @@ public class ErrorResponse extends ErrorDTO {
             if (!Utils.isCorrelationIDPresent()) {
                 errorMsg = String.format("correlationID: %s | " + errorMsg, error.getRef());
             }
-            if (isClientException && log.isDebugEnabled()) {
+            if (isClientException) {
                 if (log.isDebugEnabled()) {
                     log.debug(errorMsg, e);
                 }
@@ -138,8 +138,10 @@ public class ErrorResponse extends ErrorDTO {
             if (!Utils.isCorrelationIDPresent()) {
                 errorMsg = String.format("correlationID: %s | " + errorMsg, error.getRef());
             }
-            if (isClientException && log.isDebugEnabled()) {
-                log.debug(errorMsg);
+            if (isClientException) {
+                if (log.isDebugEnabled()) {
+                    log.debug(errorMsg);
+                }
             } else {
                 log.error(errorMsg);
             }


### PR DESCRIPTION
## Purpose
Client errors should not be logged on the server side. This PR fixes instances where client errors are logged in the  offline invite link flow

## Related Issues

- https://github.com/wso2/product-is/issues/19456