### PR TITLE
Fix session revocation issue for the sub-organization users

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/core/SessionManagementService.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -94,15 +94,8 @@ public class SessionManagementService {
     public SessionsDTO getSessionsBySessionId(User user, Integer limit, Integer offset, String filter, String sort) {
 
         String userId;
-        if (isFederatedUser()) {
-            boolean isOrganizationSSOUser = StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .getUserResidentOrganizationId());
-            // For organization SSO users, user ID resolve same as for a local user.
-            if (isOrganizationSSOUser) {
-                userId = getUserIdFromUser(user);
-            } else {
-                userId = getFederatedUserIdFromUser(user);
-            }
+        if (isFederatedUser() && !isOrganizationUser()) {
+            userId = getFederatedUserIdFromUser(user);
         } else {
             userId = getUserIdFromUser(user);
         }
@@ -118,7 +111,7 @@ public class SessionManagementService {
     public void terminateSessionBySessionId(User user, String sessionId) {
 
         String userId;
-        if (isFederatedUser()) {
+        if (isFederatedUser() && !isOrganizationUser()) {
             userId = getFederatedUserIdFromUser(user);
         } else {
             userId = getUserIdFromUser(user);
@@ -531,5 +524,11 @@ public class SessionManagementService {
                         String.format(ERROR_CODE_INVALID_DATA.getDescription(), message));
             }
         }
+    }
+
+    private boolean isOrganizationUser() {
+
+        return StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getUserResidentOrganizationId());
     }
 }


### PR DESCRIPTION
## Purpose
> Organization SSO users are federated users but not required to handles as federated users when resolving user information (ex: user-id , username). Treating as local user id/username resolving will resolve the issue.

Though we have handled the organization SSO as federated flow, there is a POC going on to handled as local users, which will be align with the assumption made here.

### Related Issue
- https://github.com/wso2/product-is/issues/20576