### PR TITLE
[Spring Cleanup] Remove Spring dependency from user common component

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.org).
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -54,11 +54,6 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose
> Remove spring dependency from user common component.

NOTE: The spring dependency has not been utilized in user common component even though the dependency has been added.

## Related Issue(s)

- https://github.com/wso2/product-is/issues/21159