### PR TITLE
Fix for issue product-is/21659

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
     public static final String STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT = "Precondition Failed";
     public static final String STATUS_INTERNAL_SERVER_ERROR_DESCRIPTION_DEFAULT =
             "The server encountered an internal error. Please contact administrator.";
+    public static final String STATUS_BAD_REQUEST_DEFAULT = "Bad Request";
 
     // Recovery type.
     public static final String RECOVERY_WITH_NOTIFICATIONS = "recoverWithNotifications";

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
@@ -256,6 +256,10 @@ public class RecoveryUtil {
                 getCode().equals(e.getErrorCode())) {
             return RecoveryUtil.buildRetryPasswordResetObject(tenantDomain, errorDescription, errorCode, code,
                     correlationId);
+        } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID.getCode().equals(
+                e.getErrorCode())) {
+            errorMessage = Constants.STATUS_BAD_REQUEST_DEFAULT;
+            status = Response.Status.BAD_REQUEST;
         }
 
         if (e instanceof IdentityRecoveryClientException) {


### PR DESCRIPTION
## Purpose
> This PR may resolve https://github.com/wso2/product-is/issues/21659

## Goals
> This PR ensures that a 400 status code is returned instead of a 500 when the API endpoint /recovery/password/recover encounters an invalid channel ID in the request body during account recovery v2.

 **Behavior After Fix:**
> Below is the Sample Request & response.
> **Request [Recover Password with invalid channel Id]**
```
curl --location 'https://localhost:9443/api/users/v2/recovery/password/recover' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic <base64 username:password>' \
--data '{
  "recoveryCode": "<recovery-code>",
  "channelId": "<invalid-channel-id>"
}'
```

> **Response [Recover Password with invalid channel Id]**
Response Code - 400
```
{
    "code": "UAR-10004",
    "message": "Bad Request",
    "description": "Channel ID does not exist",
    "traceId": "<trace-id>"
}
```