### PR TITLE
Remove travis CI status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # identity-api-user
 
-|  Branch | Build Status | Travis CI Status |
-| :------------ |:------------- |:-------------
-| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/identity-api-user/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/identity-api-user/) | [![Travis CI Status](https://travis-ci.org/wso2/identity-api-user.svg?branch=master)](https://travis-ci.org/wso2/identity-api-user?branch=master)|
+|  Branch | Build Status | 
+| :------------ |:------------- |
+| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/identity-api-user/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/identity-api-user/) |
 
 This repository contains modules related to the identity user related REST apis. It can be compiled using JDK 8, JDK 11 or JDK 17.  
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject as travis ci is no longer being used

