### PR TITLE
Retrieve all the registered password recovery managers

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/UserAccountRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/UserAccountRecoveryServiceDataHolder.java
@@ -15,8 +15,11 @@
  */
 package org.wso2.carbon.identity.api.user.recovery.commons;
 
+import org.wso2.carbon.identity.recovery.internal.service.impl.password.PasswordRecoveryManagerImpl;
 import org.wso2.carbon.identity.recovery.services.password.PasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.services.username.UsernameRecoveryManager;
+
+import java.util.List;
 
 /**
  * Service holder class for user account recovery.
@@ -24,7 +27,7 @@ import org.wso2.carbon.identity.recovery.services.username.UsernameRecoveryManag
 public class UserAccountRecoveryServiceDataHolder {
 
     private static UsernameRecoveryManager usernameRecoveryManager;
-    private static PasswordRecoveryManager passwordRecoveryManager;
+    private static List<PasswordRecoveryManager> passwordRecoveryManager;
 
     /**
      * Get UsernameRecoveryManager instance.
@@ -53,6 +56,22 @@ public class UserAccountRecoveryServiceDataHolder {
      */
     public static PasswordRecoveryManager getPasswordRecoveryManager() {
 
+        // Return the default notification based passwordRecoveryManager.
+        for (PasswordRecoveryManager manager : passwordRecoveryManager) {
+            if (manager instanceof PasswordRecoveryManagerImpl) {
+                return manager;
+            }
+        }
+        return UserAccountRecoveryServiceDataHolder.passwordRecoveryManager.get(0);
+    }
+
+    /**
+     * Get all PasswordRecoveryManager instances.
+     *
+     * @return List of PasswordRecoveryManager.
+     */
+    public static List<PasswordRecoveryManager> getPasswordRecoveryManagers() {
+
         return UserAccountRecoveryServiceDataHolder.passwordRecoveryManager;
     }
 
@@ -62,7 +81,7 @@ public class UserAccountRecoveryServiceDataHolder {
      * @param passwordRecoveryManager PasswordRecoveryManager
      */
     public static void setPasswordRecoveryManager(
-            PasswordRecoveryManager passwordRecoveryManager) {
+            List<PasswordRecoveryManager> passwordRecoveryManager) {
 
         UserAccountRecoveryServiceDataHolder.passwordRecoveryManager = passwordRecoveryManager;
     }

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/UserAccountRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/UserAccountRecoveryServiceDataHolder.java
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.wso2.carbon.identity.api.user.recovery.commons;
 
 import org.wso2.carbon.identity.recovery.internal.service.impl.password.PasswordRecoveryManagerImpl;

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/factory/PasswordRecoveryManagerOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/factory/PasswordRecoveryManagerOSGIServiceFactory.java
@@ -19,12 +19,15 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.recovery.services.password.PasswordRecoveryManager;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This factory bean is used to instantiate PasswordRecoveryManager type object inside the container.
  */
-public class PasswordRecoveryManagerOSGIServiceFactory extends AbstractFactoryBean<PasswordRecoveryManager> {
+public class PasswordRecoveryManagerOSGIServiceFactory extends AbstractFactoryBean<List<PasswordRecoveryManager>> {
 
-    private PasswordRecoveryManager passwordRecoveryManager;
+    private List<PasswordRecoveryManager> passwordRecoveryManager;
 
     @Override
     public Class<?> getObjectType() {
@@ -33,13 +36,20 @@ public class PasswordRecoveryManagerOSGIServiceFactory extends AbstractFactoryBe
     }
 
     @Override
-    protected PasswordRecoveryManager createInstance() throws Exception {
+    protected List<PasswordRecoveryManager> createInstance() throws Exception {
 
         if (this.passwordRecoveryManager == null) {
-            PasswordRecoveryManager passwordRecoveryManager = (PasswordRecoveryManager) PrivilegedCarbonContext
-                    .getThreadLocalCarbonContext().getOSGiService(PasswordRecoveryManager.class, null);
-            if (passwordRecoveryManager != null) {
-                this.passwordRecoveryManager = passwordRecoveryManager;
+            List<Object> passwordRecoveryManagerList = PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getOSGiServices(PasswordRecoveryManager.class, null);
+
+            List<PasswordRecoveryManager> managers = new ArrayList<>();
+            for (Object manager : passwordRecoveryManagerList) {
+                if (manager instanceof PasswordRecoveryManager) {
+                    managers.add((PasswordRecoveryManager) manager);
+                }
+            }
+            if (!managers.isEmpty()) {
+                this.passwordRecoveryManager = managers;
             } else {
                 throw new Exception("Unable to retrieve PasswordRecoveryManager service.");
             }

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/factory/PasswordRecoveryManagerOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.api.user.recovery.commons/src/main/java/org/wso2/carbon/identity/api/user/recovery/commons/factory/PasswordRecoveryManagerOSGIServiceFactory.java
@@ -1,18 +1,21 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.wso2.carbon.identity.api.user.recovery.commons.factory;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/PasswordRecoveryService.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/PasswordRecoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -441,6 +441,9 @@ public class PasswordRecoveryService {
                                                                         RecoveryInformationDTO recoveryInformationDTO) {
 
         ArrayList<AccountRecoveryType> accountRecoveryTypes = new ArrayList<>();
+        if (recoveryInformationDTO == null) {
+            return accountRecoveryTypes;
+        }
         boolean isNotificationBasedRecoveryEnabled = recoveryInformationDTO.isNotificationBasedRecoveryEnabled();
         boolean isQuestionBasedRecoveryAllowedForUser = recoveryInformationDTO.isQuestionBasedRecoveryAllowedForUser();
         if (isNotificationBasedRecoveryEnabled) {

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/PasswordRecoveryService.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/PasswordRecoveryService.java
@@ -91,6 +91,8 @@ public class PasswordRecoveryService {
                                 RecoveryUtil.buildPropertiesMap(initRequest.getProperties()));
                 if (!(manager instanceof PasswordRecoveryManagerImpl)) {
                     // Get the challenge question based password recovery configurations.
+                    LOG.debug("Considering PasswordRecoveryManager to be ChallengeQuestionPasswordRecoveryManager " +
+                            "and retrieving question-based recovery configurations.");
                     isQuestionBasedRecoveryEnabled = tempDTO.isQuestionBasedRecoveryEnabled();
                     isQuestionBasedRecoveryAllowedForUser = tempDTO.isQuestionBasedRecoveryAllowedForUser();
                 } else {


### PR DESCRIPTION
## Purpose
The previous data holder could keep one PasswordRecoveryManager implementation at once. But there can be multiple implementations, hence it should be a list, and the API should response with respect to all the available PasswordRecoveryManager implementations in order to proceed for the next steps of the password recovery via the API.

### Related Issues
- https://github.com/wso2/product-is/issues/21106

