### PR TITLE
Update pr-builder.yml bump actions/cache version

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:


### PR DESCRIPTION
## Purpose
Bump actions/cache version since v2 is deprecated.
<img width="827" alt="Screenshot 2025-03-26 at 16 41 31" src="https://github.com/user-attachments/assets/06603004-1306-49c5-8af4-bab47cb80e88" />

## Related Issues
- https://github.com/wso2/product-is/issues/23500