### PR TITLE
Fix incorrect error message format returned by V2 Recovery API on validation failure during SMS OTP recovery flow triggered by pre-update password action.

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
@@ -263,15 +263,12 @@ public class RecoveryUtil {
         }
 
         if (e instanceof IdentityRecoveryClientException) {
-            status = Response.Status.BAD_REQUEST;
-
             if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode()
                     .equals(e.getErrorCode())) {
                 IdentityRecoveryClientException identityRecoveryClientException = (IdentityRecoveryClientException) e;
-                ErrorResponse errorResponse =
-                        buildErrorResponse(errorCode, identityRecoveryClientException.getMessage(),
-                                identityRecoveryClientException.getDescription());
-                return new APIError(status, errorResponse);
+                status = Response.Status.BAD_REQUEST;
+                errorMessage = identityRecoveryClientException.getMessage();
+                errorDescription = identityRecoveryClientException.getDescription();
             }
             return buildClientError(errorCode, errorMessage, errorDescription, status);
         }

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
@@ -263,6 +263,16 @@ public class RecoveryUtil {
         }
 
         if (e instanceof IdentityRecoveryClientException) {
+            status = Response.Status.BAD_REQUEST;
+
+            if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode()
+                    .equals(e.getErrorCode())) {
+                IdentityRecoveryClientException identityRecoveryClientException = (IdentityRecoveryClientException) e;
+                ErrorResponse errorResponse =
+                        buildErrorResponse(errorCode, identityRecoveryClientException.getMessage(),
+                                identityRecoveryClientException.getDescription());
+                return new APIError(status, errorResponse);
+            }
             return buildClientError(errorCode, errorMessage, errorDescription, status);
         }
         return buildServerError(e, e.getErrorCode(), errorMessage, serverErrorDescription, status);

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.10.25</carbon.kernel.version>
-        <identity.governance.version>1.11.54</identity.governance.version>
+        <identity.governance.version>1.11.60</identity.governance.version>
         <carbon.identity.framework.version>7.8.30</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0]</carbon.identity.framework.version.range>
         <carbon.identity.account.association.version>5.5.10</carbon.identity.account.association.version>

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.10.25</carbon.kernel.version>
-        <identity.governance.version>1.11.8</identity.governance.version>
+        <identity.governance.version>1.11.54</identity.governance.version>
         <carbon.identity.framework.version>7.8.30</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0]</carbon.identity.framework.version.range>
         <carbon.identity.account.association.version>5.5.10</carbon.identity.account.association.version>


### PR DESCRIPTION
Fix incorrect error message format returned by V2 Recovery API on validation failure during SMS OTP recovery flow triggered by pre-update password action.

Parent issue : 

- https://github.com/wso2/product-is/issues/23768

Fixed error format

```
{
    "code": "PWR-20067",
    "message": "invalid_format",
    "description": "Invalid password format.",
    "traceId": "83bb46e4-f6d2-48dd-99e8-8f5f37a288d5"
}
```