### PR TITLE
Set flows for session termination

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/MeApiServiceImpl.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.rest.api.user.session.v1.impl;
 
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.rest.api.user.session.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.dto.SessionsDTO;
@@ -60,6 +62,7 @@ public class MeApiServiceImpl extends MeApiService {
     @Override
     public Response terminateSessionByLoggedInUser(String sessionId) {
 
+        setFlowValues();
         sessionManagementService.terminateSessionBySessionId(getUserFromContext(), sessionId);
 
         return Response.noContent().build();
@@ -68,8 +71,18 @@ public class MeApiServiceImpl extends MeApiService {
     @Override
     public Response terminateSessionsByLoggedInUser() {
 
+        setFlowValues();
         sessionManagementService.terminateSessionsByUserId(getUserFromContext());
 
         return Response.noContent().build();
+    }
+
+    private void setFlowValues() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.SESSION_REVOKE)
+                .initiatingPersona(Flow.InitiatingPersona.USER)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.session/org.wso2.carbon.identity.api.user.session.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/session/v1/impl/UserIdApiServiceImpl.java
@@ -24,6 +24,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.api.user.common.Util;
 import org.wso2.carbon.identity.api.user.session.common.util.SessionManagementServiceHolder;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.rest.api.user.session.v1.UserIdApiService;
 import org.wso2.carbon.identity.rest.api.user.session.v1.core.SessionManagementService;
@@ -35,6 +37,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.util.Optional;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -89,6 +92,7 @@ public class UserIdApiServiceImpl extends UserIdApiService {
 
         Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
                 IdentityTenantUtil.resolveTenantDomain());
+        setFlowValues();
         sessionManagementService.terminateSessionBySessionId(userId, sessionId);
         return Response.noContent().build();
     }
@@ -121,12 +125,21 @@ public class UserIdApiServiceImpl extends UserIdApiService {
 
             Util.validateUserId(SessionManagementServiceHolder.getRealmService(), userId,
                     IdentityTenantUtil.resolveTenantDomain());
+            setFlowValues();
             sessionManagementService.terminateSessionsByUserId(userId);
             return Response.noContent().build();
         } catch (UserStoreException e) {
             log.error("Error occurred while invoking userstore manager.", e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
+    }
 
+    private void setFlowValues() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.SESSION_REVOKE)
+                .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.10.25</carbon.kernel.version>
         <identity.governance.version>1.11.60</identity.governance.version>
-        <carbon.identity.framework.version>7.8.30</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.146</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0]</carbon.identity.framework.version.range>
         <carbon.identity.account.association.version>5.5.10</carbon.identity.account.association.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>


### PR DESCRIPTION
## Purpose
- Set the Flow values for the User Session Termination workflows.
- This is needed for CAEP and WSO2 Eventing Profiles.

## Goals
- When a termination event is received, the IdentityContext Flow value will be set to SESSION_REVOKE and InitiatingPersona will be set to either ADMIN or USER depending on the flow.

## Approach
- A new private function will be called in user session termination flows, which sets the IdentityContext ThreadLocalIdentityContext.

### Related Product-IS Issue:
- https://github.com/wso2/product-is/issues/24072