### PR TITLE
Provide Authenticated User to Verify TOTP Code

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.totp/org.wso2.carbon.identity.api.user.totp.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/totp/v1/core/TOTPService.java
+++ b/components/org.wso2.carbon.identity.api.user.totp/org.wso2.carbon.identity.api.user.totp.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/totp/v1/core/TOTPService.java
@@ -267,7 +267,7 @@ public class TOTPService {
                 log.debug("Validating TOTP verification code for the user: " + username);
             }
             totpResponseDTO.setIsValid(totpAuthenticator.
-                    authorizeAndStoreSecret(verificationCode, username));
+                    authorizeAndStoreSecret(verificationCode, username, getUser()));
         } catch (AuthenticationFailedException e) {
             throw handleException(e, USER_ERROR_UNAUTHORIZED_USER);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <identity.notification.push.version.range>[1.0.0, 2.0.0)</identity.notification.push.version.range>
         <testng.version>6.9.10</testng.version>
         <fido2.version>5.4.7</fido2.version>
-        <identity.totp.version>3.3.1</identity.totp.version>
+        <identity.totp.version>3.3.40</identity.totp.version>
         <identity.backup.code.version>0.0.4</identity.backup.code.version>
         <lombok.version>1.18.20</lombok.version>
         <identity.verification.version>1.0.16</identity.verification.version>


### PR DESCRIPTION
As the authenticated user is required to obtain and update some claims, it is being passed alongwith to the TOTP verification. 

Issue : https://github.com/wso2/product-is/issues/25205