### PR TITLE
Return NOT_FOUND response when approval not found.

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.approval/org.wso2.carbon.identity.rest.api.user.approval.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/approval/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.approval/org.wso2.carbon.identity.rest.api.user.approval.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/approval/v1/impl/MeApiServiceImpl.java
@@ -18,10 +18,14 @@
 
 package org.wso2.carbon.identity.rest.api.user.approval.v1.impl;
 
+import org.wso2.carbon.identity.api.user.approval.common.ApprovalConstant;
+import org.wso2.carbon.identity.api.user.common.error.APIError;
+import org.wso2.carbon.identity.api.user.common.error.ErrorResponse;
 import org.wso2.carbon.identity.rest.api.user.approval.v1.MeApiService;
 import org.wso2.carbon.identity.rest.api.user.approval.v1.core.factories.ApprovalEventServiceFactory;
 import org.wso2.carbon.identity.rest.api.user.approval.v1.model.StateDTO;
 import org.wso2.carbon.identity.workflow.engine.ApprovalTaskService;
+import org.wso2.carbon.identity.workflow.engine.dto.ApprovalTaskDTO;
 import org.wso2.carbon.identity.workflow.engine.exception.WorkflowEngineException;
 
 import java.util.List;
@@ -46,7 +50,14 @@ public class MeApiServiceImpl implements MeApiService {
     public Response getApprovalTaskInfo(String taskId) {
 
         try {
-            return Response.ok().entity(approvalEventService.getApprovalTaskByTaskId(taskId)).build();
+            ApprovalTaskDTO task = approvalEventService.getApprovalTaskByTaskId(taskId);
+            if (task == null) {
+                throw new APIError(Response.Status.NOT_FOUND, new ErrorResponse.Builder().withCode(
+                                ApprovalConstant.ErrorMessage.USER_ERROR_NON_EXISTING_TASK_ID.getCode())
+                        .withMessage(ApprovalConstant.ErrorMessage.USER_ERROR_NON_EXISTING_TASK_ID.getMessage())
+                        .build());
+            }
+            return Response.ok().entity(task).build();
         } catch (WorkflowEngineException e) {
             throw handleError(e);
         }


### PR DESCRIPTION
## Purpose
$subject

This pull request improves error handling in the `MeApiServiceImpl` class for the user approval API. The main change is to provide a clear error response when a requested approval task does not exist, instead of returning a null or empty response.

**Error handling improvements:**

* Added a check in `getApprovalTaskInfo` to return a `404 NOT FOUND` error with a descriptive message if the approval task with the given `taskId` does not exist, using the `APIError` and `ErrorResponse` classes.

**Dependency and import updates:**

* Imported `ApprovalConstant`, `APIError`, and `ErrorResponse` to support the new error handling logic.


### Related Issues
- https://github.com/wso2/product-is/issues/25907

### Related PRs
- https://github.com/wso2-extensions/identity-workflow/pull/28