### PR TITLE
Add endpoint to update push device from mobile

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
@@ -152,7 +152,7 @@ public class DevicesApi  {
     @Produces({ "application/json" })
     @ApiOperation(value = "Update a registered device from the mobile device.", notes = "This API is used to update a registered device through the mobile device. ", response = Void.class, tags={ "device" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "The device was updated successfully.", response = Void.class),
+        @ApiResponse(code = 204, message = "The device was updated successfully.", response = Void.class),
         @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
         @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
         @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
@@ -150,7 +150,7 @@ public class DevicesApi  {
     @Path("/{deviceId}/update")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update a registered device from the device.", notes = "This API is used to update a registered device through device. ", response = Void.class, tags={ "device" })
+    @ApiOperation(value = "Update a registered device from the mobile device.", notes = "This API is used to update a registered device through the mobile device. ", response = Void.class, tags={ "device" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "The device was updated successfully.", response = Void.class),
         @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
@@ -158,7 +158,7 @@ public class DevicesApi  {
         @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response updateDeviceFromMobile(@ApiParam(value = "ID of the device to be updated",required=true) @PathParam("deviceId") String deviceId, @ApiParam(value = "Update request sent from the device." ,required=true) @Valid UpdateRequestDTO updateRequestDTO) {
+    public Response updateDeviceFromMobile(@ApiParam(value = "ID of the device to be updated",required=true) @PathParam("deviceId") String deviceId, @ApiParam(value = "Update request sent from the mobile device." ,required=true) @Valid UpdateRequestDTO updateRequestDTO) {
 
         return delegate.updateDeviceFromMobile(deviceId,  updateRequestDTO );
     }

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.rest.api.user.push.v1.model.DeviceDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.Error;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RegistrationRequestDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RemoveRequestDTO;
+import org.wso2.carbon.identity.rest.api.user.push.v1.model.UpdateRequestDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.DevicesApiService;
 
 import javax.validation.Valid;
@@ -142,6 +143,24 @@ public class DevicesApi  {
     public Response removeDeviceFromMobile(@ApiParam(value = "ID of the device to be removed",required=true) @PathParam("deviceId") String deviceId, @ApiParam(value = "Remove request sent from the device." ,required=true) @Valid RemoveRequestDTO removeRequestDTO) {
 
         return delegate.removeDeviceFromMobile(deviceId,  removeRequestDTO );
+    }
+
+    @Valid
+    @POST
+    @Path("/{deviceId}/update")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update a registered device from the device.", notes = "This API is used to update a registered device through device. ", response = Void.class, tags={ "device" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "The device was updated successfully.", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response updateDeviceFromMobile(@ApiParam(value = "ID of the device to be updated",required=true) @PathParam("deviceId") String deviceId, @ApiParam(value = "Update request sent from the device." ,required=true) @Valid UpdateRequestDTO updateRequestDTO) {
+
+        return delegate.updateDeviceFromMobile(deviceId,  updateRequestDTO );
     }
 
 }

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/DevicesApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.rest.api.user.push.v1.model.DeviceDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.Error;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RegistrationRequestDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RemoveRequestDTO;
+import org.wso2.carbon.identity.rest.api.user.push.v1.model.UpdateRequestDTO;
 import javax.ws.rs.core.Response;
 
 
@@ -42,4 +43,6 @@ public interface DevicesApiService {
       public Response registerDevice(RegistrationRequestDTO registrationRequestDTO);
 
       public Response removeDeviceFromMobile(String deviceId, RemoveRequestDTO removeRequestDTO);
+
+      public Response updateDeviceFromMobile(String deviceId, UpdateRequestDTO updateRequestDTO);
 }

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/model/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/model/UpdateRequestDTO.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.user.push.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Update device request body sent from the device
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Update device request body sent from the device")
+public class UpdateRequestDTO  {
+  
+    private String token;
+
+    /**
+    * JWT containing the update device information signed with a unique private key
+    **/
+    public UpdateRequestDTO token(String token) {
+
+        this.token = token;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "signedJWTToken", required = true, value = "JWT containing the update device information signed with a unique private key")
+    @JsonProperty("token")
+    @Valid
+    @NotNull(message = "Property token cannot be null.")
+
+    public String getToken() {
+        return token;
+    }
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateRequestDTO updateRequestDTO = (UpdateRequestDTO) o;
+        return Objects.equals(this.token, updateRequestDTO.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UpdateRequestDTO {\n");
+        
+        sb.append("    token: ").append(toIndentedString(token)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/model/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/gen/java/org/wso2/carbon/identity/rest/api/user/push/v1/model/UpdateRequestDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,20 +25,20 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 
 /**
- * Update device request body sent from the device
+ * Update device request body sent from the mobile device
  **/
 
 import io.swagger.annotations.*;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
-@ApiModel(description = "Update device request body sent from the device")
+@ApiModel(description = "Update device request body sent from the mobile device")
 public class UpdateRequestDTO  {
   
     private String token;
 
     /**
-    * JWT containing the update device information signed with a unique private key
+    * JWT containing the device information to be updated signed with the unique private key
     **/
     public UpdateRequestDTO token(String token) {
 
@@ -46,7 +46,7 @@ public class UpdateRequestDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "signedJWTToken", required = true, value = "JWT containing the update device information signed with a unique private key")
+    @ApiModelProperty(example = "signedJWTToken", required = true, value = "JWT containing the device information to be updated signed with the unique private key")
     @JsonProperty("token")
     @Valid
     @NotNull(message = "Property token cannot be null.")

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
@@ -150,6 +150,21 @@ public class PushDeviceManagementService {
     }
 
     /**
+     * Update device from mobile.
+     *
+     * @param deviceId Device ID.
+     * @param token    Token.
+     */
+    public void updateDeviceFromMobile(String deviceId, String token) {
+
+        try {
+            deviceHandlerService.editDeviceMobile(deviceId, token);
+        } catch (PushDeviceHandlerException e) {
+            throw handlePushDeviceHandlerException(e);
+        }
+    }
+
+    /**
      * Register a device.
      *
      * @param registrationRequestDTO Registration request DTO.

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
@@ -79,7 +79,7 @@ public class DevicesApiServiceImpl implements DevicesApiService {
 
         String token = updateRequestDTO.getToken();
         pushDeviceManagementService.updateDeviceFromMobile(deviceId, token);
-        return Response.status(Response.Status.OK).build();
+        return Response.noContent().build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.rest.api.user.push.v1.factories.PushDeviceManage
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.DeviceDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RegistrationRequestDTO;
 import org.wso2.carbon.identity.rest.api.user.push.v1.model.RemoveRequestDTO;
+import org.wso2.carbon.identity.rest.api.user.push.v1.model.UpdateRequestDTO;
 
 import java.util.List;
 
@@ -71,6 +72,14 @@ public class DevicesApiServiceImpl implements DevicesApiService {
 
         pushDeviceManagementService.registerDevice(registrationRequestDTO);
         return Response.status(Response.Status.CREATED).build();
+    }
+
+    @Override
+    public Response updateDeviceFromMobile(String deviceId, UpdateRequestDTO updateRequestDTO) {
+
+        String token = updateRequestDTO.getToken();
+        pushDeviceManagementService.updateDeviceFromMobile(deviceId, token);
+        return Response.status(Response.Status.OK).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
@@ -147,6 +147,39 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/ServerError'
+  /devices/{deviceId}/update:
+    post:
+      tags:
+        - device
+      description: |
+        This API is used to update a registered device through device.
+      summary: Update a registered device from the device.
+      operationId: updateDeviceFromMobile
+      parameters:
+        - name: deviceId
+          in: path
+          description: ID of the device to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Update request sent from the device.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRequestDTO'
+      responses:
+        '200':
+          description: The device was updated successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /devices/{deviceId}/remove:
     post:
       tags:
@@ -285,6 +318,16 @@ components:
           description: Provider metadata as key-value pairs
           additionalProperties:
             type: string
+    UpdateRequestDTO:
+      type: object
+      description: Update device request body sent from the device
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: JWT containing the update device information signed with a unique private key
+          example: 'signedJWTToken'
     RemoveRequestDTO:
       type: object
       description: Remove device request body sent from the device

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
@@ -170,7 +170,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateRequestDTO'
       responses:
-        '200':
+        '204':
           description: The device was updated successfully.
         '400':
           $ref: '#/components/responses/BadRequest'

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/resources/push.yaml
@@ -152,8 +152,8 @@ paths:
       tags:
         - device
       description: |
-        This API is used to update a registered device through device.
-      summary: Update a registered device from the device.
+        This API is used to update a registered device through the mobile device.
+      summary: Update a registered device from the mobile device.
       operationId: updateDeviceFromMobile
       parameters:
         - name: deviceId
@@ -163,7 +163,7 @@ paths:
           schema:
             type: string
       requestBody:
-        description: Update request sent from the device.
+        description: Update request sent from the mobile device.
         required: true
         content:
           application/json:
@@ -320,13 +320,13 @@ components:
             type: string
     UpdateRequestDTO:
       type: object
-      description: Update device request body sent from the device
+      description: Update device request body sent from the mobile device
       required:
         - token
       properties:
         token:
           type: string
-          description: JWT containing the update device information signed with a unique private key
+          description: JWT containing the device information to be updated signed with the unique private key
           example: 'signedJWTToken'
     RemoveRequestDTO:
       type: object


### PR DESCRIPTION
## Purpose
 Add a REST API endpoint to allow mobile devices to update their registered push device properties (device name and device token). This complements the existing device registration and removal endpoints by enabling in-place updates from the device side.

## Related Issue
 - https://github.com/wso2/product-is/issues/26207

## Related PRs
 - **(prerequisite)** https://github.com/wso2-extensions/identity-notification-push/pull/25
 - https://github.com/wso2/carbon-identity-framework/pull/8086

## Goals
 - Expose a new `POST /devices/{deviceId}/update` endpoint in the push device REST API.
 - Allow mobile devices to send a signed JWT containing updated device properties.
 - Integrate with the `DeviceHandlerService.editDeviceMobile()` method from the `identity-notification-push` component.

## Approach
 - Defined the new `/devices/{deviceId}/update` path in the OpenAPI spec (`push.yaml`) with `UpdateRequestDTO` schema containing a `token` field (signed JWT).
 - Added `UpdateRequestDTO` model class in the generated code layer.
 - Added `updateDeviceFromMobile()` method to `DevicesApiService` interface and its implementation in `DevicesApiServiceImpl`, which extracts the token from the request body and delegates to the core service.
 - Added `updateDeviceFromMobile()` method in `PushDeviceManagementService` that calls `deviceHandlerService.editDeviceMobile(deviceId, token)` and handles exceptions.
 - Updated `DevicesApi` JAX-RS resource class with the new endpoint annotation and routing.

## User stories
 As a mobile app user, I want to be able to update my device's push notification token or device name via the REST API so that push notifications continue to work correctly after token rotation or device rename.

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
 Added a new REST API endpoint `POST /devices/{deviceId}/update` to allow mobile devices to update their registered push device properties (device token, device name) using a signed JWT.

## Documentation
 Will update

## Training
 N/A

## Certification
 N/A - New API endpoint addition with no impact on existing certification content.

## Marketing
 N/A

## Automation tests
 - Unit tests
   N/A - This layer is a thin REST API delegation to the core `identity-notification-push` component, which has unit test coverage for the underlying `editDeviceMobile` logic.
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 N/A

## Migrations (if applicable)
 No migrations required.

## Learning
 Followed the existing pattern used by the `removeDeviceFromMobile` endpoint (`/devices/{deviceId}/remove`) for structuring the new update endpoint, request DTO, and service delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /devices/{deviceId}/update to allow mobile clients to update device info.
  * Request body requires a JSON with a token (JWT carrying device-update data).
  * Successful requests return 204 No Content.
* **Bug Fixes / Behavior**
  * Server now handles token-based device updates with proper error mapping for client and server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->