### PR TITLE
Fix NPE in ContextLoader when retrieving sessions for sub-org native user

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
@@ -83,7 +83,7 @@ public class ContextLoader {
         String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         String username = getUsernameFromContext();
 
-        if (!StringUtils.isNotEmpty(username) && isOrganizationUser()) {
+        if (StringUtils.isEmpty(username) && isOrganizationUser()) {
             return getUserFromOrganizationContext(tenantDomain);
         }
         return getUser(tenantDomain, username);
@@ -99,7 +99,7 @@ public class ContextLoader {
 
         LOG.debug("Resolving user from organization context for tenant domain: " + tenantDomain);
         String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-        if (!StringUtils.isNotEmpty(userId)) {
+        if (StringUtils.isEmpty(userId)) {
             throw new APIError(Response.Status.INTERNAL_SERVER_ERROR,
                     new ErrorResponse.Builder()
                             .withDescription("Unable to resolve user from organization context.")

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,44 @@ public class ContextLoader {
      */
     public static User getUserFromContext() {
 
-        return getUser(IdentityTenantUtil.resolveTenantDomain(), getUsernameFromContext());
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        String username = getUsernameFromContext();
+
+        if (StringUtils.isBlank(username) && isOrganizationUser()) {
+            return getUserFromOrganizationContext(tenantDomain);
+        }
+        return getUser(tenantDomain, username);
+    }
+
+    private static boolean isOrganizationUser() {
+
+        return StringUtils.isNotEmpty(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserResidentOrganizationId());
+    }
+
+    private static User getUserFromOrganizationContext(String tenantDomain) {
+
+        String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+        if (StringUtils.isBlank(userId)) {
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR,
+                    new ErrorResponse.Builder()
+                            .withDescription("Unable to resolve user from organization context.")
+                            .withCode(ERROR_CODE_SERVER_ERROR.getCode())
+                            .withMessage(ERROR_CODE_SERVER_ERROR.getMessage()).build());
+        }
+        try {
+            UserRealm userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
+            AbstractUserStoreManager userStoreManager =
+                    (AbstractUserStoreManager) userRealm.getUserStoreManager();
+            String username = userStoreManager.getUserNameFromUserID(userId);
+            return getUser(tenantDomain, username);
+        } catch (UserStoreException e) {
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR,
+                    new ErrorResponse.Builder()
+                            .withDescription("Error occurred while resolving the user from organization context.")
+                            .withCode(ERROR_CODE_SERVER_ERROR.getCode())
+                            .withMessage(ERROR_CODE_SERVER_ERROR.getMessage()).build());
+        }
     }
 
 

--- a/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
+++ b/components/org.wso2.carbon.identity.api.user.common/src/main/java/org/wso2/carbon/identity/api/user/common/ContextLoader.java
@@ -83,7 +83,7 @@ public class ContextLoader {
         String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         String username = getUsernameFromContext();
 
-        if (StringUtils.isBlank(username) && isOrganizationUser()) {
+        if (!StringUtils.isNotEmpty(username) && isOrganizationUser()) {
             return getUserFromOrganizationContext(tenantDomain);
         }
         return getUser(tenantDomain, username);
@@ -97,8 +97,9 @@ public class ContextLoader {
 
     private static User getUserFromOrganizationContext(String tenantDomain) {
 
+        LOG.debug("Resolving user from organization context for tenant domain: " + tenantDomain);
         String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-        if (StringUtils.isBlank(userId)) {
+        if (!StringUtils.isNotEmpty(userId)) {
             throw new APIError(Response.Status.INTERNAL_SERVER_ERROR,
                     new ErrorResponse.Builder()
                             .withDescription("Unable to resolve user from organization context.")
@@ -112,6 +113,7 @@ public class ContextLoader {
             String username = userStoreManager.getUserNameFromUserID(userId);
             return getUser(tenantDomain, username);
         } catch (UserStoreException e) {
+            LOG.error("Error occurred while resolving username from userId: " + userId);
             throw new APIError(Response.Status.INTERNAL_SERVER_ERROR,
                     new ErrorResponse.Builder()
                             .withDescription("Error occurred while resolving the user from organization context.")


### PR DESCRIPTION
### Purpose
Fix a `NullPointerException` that occurs when a native sub-organization user calls the User Sessions API (`/o/api/users/v1/me/sessions`) using an access token obtained via Authorization Code Grant.

### Goals
- Eliminate the 500 Internal Server Error returned to sub-org native users calling `/me/sessions`
- Ensure regular tenant users and federated users are completely unaffected
- Follow existing patterns already established in the codebase for handling organization users

### Approach
The root cause is that access tokens issued for sub-org native users do not contain a `username` claim but only a UUID `sub` claim. `ContextLoader.getUserFromContext()` assumed a username was always present and crashed with an NPE when trying to call `.split()` on a null value.

The fix adds a fallback path in `getUserFromContext()`: when the username is blank and the request is from an organization user (detected via `getUserResidentOrganizationId()`, consistent with how `SessionManagementService` already does this), the user is resolved by looking up the username from the UUID using `AbstractUserStoreManager.getUserNameFromUserID()`. The resolved username is in `DOMAIN/username` format which is exactly what the existing `getUser()` method expects.

### Related Issues
 - https://github.com/wso2/product-is/issues/26811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user context resolution for organization users when username is missing, ensuring correct identification via organization context.
  * Added fallback resolution that maps organization user identifiers to usernames for reliable lookup in multi-tenant environments.
  * Enhanced error handling and debug logging for organization user resolution to surface failures more clearly and aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->