### PR TITLE
Fix swapped code and description in password reset retry error response

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
@@ -374,7 +374,7 @@ public class RecoveryUtil {
                         buildURIForBody(tenantDomain, Constants.APICall.RESET_PASSWORD_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
         RetryErrorResponse retryErrorResponse = buildRetryErrorResponse(
-                Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, code, description, resetCode, correlationId,
+                Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode, correlationId,
                 apiCallsArrayList);
         if (StringUtils.isNotBlank(className)) {
             description = String.format("%s : %s - %s", LOG_MESSAGE_PREFIX, className, description);

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
@@ -424,7 +424,7 @@ public class RecoveryUtil {
                     apiCallsArrayList);
         } else {
             retryErrorResponse = buildRetryErrorResponse(
-                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, code, description, resetCode,
+                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode,
                     correlationId, apiCallsArrayList);
         }
         LOG.debug(description);

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v2/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v2/impl/core/utils/RecoveryUtil.java
@@ -417,16 +417,9 @@ public class RecoveryUtil {
                         buildURIForBody(tenantDomain, APICalls.RESET_PASSWORD_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
 
-        RetryErrorResponse retryErrorResponse;
-        if (isNormalizedRetryErrorResponseEnabled()) {
-            retryErrorResponse = buildRetryErrorResponse(
-                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode, correlationId,
-                    apiCallsArrayList);
-        } else {
-            retryErrorResponse = buildRetryErrorResponse(
-                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode,
-                    correlationId, apiCallsArrayList);
-        }
+        RetryErrorResponse retryErrorResponse = buildRetryErrorResponse(
+                Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode, correlationId,
+                apiCallsArrayList);
         LOG.debug(description);
         return new PreconditionFailedException(retryErrorResponse);
     }


### PR DESCRIPTION
## Summary

When password history validation fails during password reset (`POST /api/users/v2/recovery/password/reset`), the HTTP 412 response has `code` and `description` fields transposed: the human-readable message appears in `code` and the error code (`PWR-10005`) appears in `description`.

**Root cause:** `buildRetryPasswordResetObject()` calls `buildRetryErrorResponse(message, description, code, ...)` but was passing arguments in the wrong order: `buildRetryErrorResponse(message, code, description, ...)`.

- **v1 API:** Unconditional fix — swapped `code, description` → `description, code` in `buildRetryPasswordResetObject()`.
- **v2 API:** The `if (isNormalizedRetryErrorResponseEnabled())` branch already had the correct order. Fixed the `else` branch (legacy path) to match.

**Before:**
```json
{
  "code": "This password has been used in recent history. Please choose a different password",
  "description": "PWR-10005"
}
```

**After:**
```json
{
  "code": "PWR-10005",
  "description": "This password has been used in recent history. Please choose a different password"
}
```

## Related Issue

- https://github.com/wso2/product-is/issues/27755

## Test plan

- [ ] Enable password history validation (`passwordHistory.enable=true`, count ≥ 2)
- [ ] Complete the password recovery flow: `init` → `recover` → `confirm` → `reset` with a previously-used password
- [ ] Verify the HTTP 412 response has `code: "PWR-10005"` and `description` containing the human-readable message
- [ ] Verify with `EnableNormalizedRetryErrorResponse=false` (v2 else branch) and with the flag omitted (default)