### PR TITLE
[identity-api-user] Bump Jackson to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,9 +522,9 @@
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <jackson-jaxrs-json-provider.version>2.18.0</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.16.1</jackson-databind.version>
-        <jackson-dataformat-xml.version>2.16.1</jackson-dataformat-xml.version>
+        <jackson-jaxrs-json-provider.version>2.21.2</jackson-jaxrs-json-provider.version>
+        <jackson-databind.version>2.21.2</jackson-databind.version>
+        <jackson-dataformat-xml.version>2.21.2</jackson-dataformat-xml.version>
         <cxf-bundle.version>3.5.9</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the mixed 2.16.x / 2.18.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `jackson-databind.version` → `2.21.2`
- `jackson-dataformat-xml.version` → `2.21.2`
- `jackson-jaxrs-json-provider.version` → `2.21.2`