### PR TITLE
Fix swapped code and description in v1 password reset retry error response

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/Constants.java
@@ -36,6 +36,9 @@ public class Constants {
     public static final String STATUS_INTERNAL_SERVER_ERROR_DESCRIPTION_DEFAULT =
             "The server encountered an internal error. Please contact administrator.";
 
+    public static final String ENABLE_NORMALIZED_RETRY_ERROR_RESPONSE =
+            "Recovery.ErrorMessage.EnableNormalizedRetryErrorResponse";
+
     // Recovery type.
     public static final String RECOVERY_WITH_NOTIFICATIONS = "recoverWithNotifications";
     public static final String RECOVER_WITH_CHALLENGE_QUESTIONS = "recoverWithChallengeQuestions";

--- a/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/org.wso2.carbon.identity.rest.api.user.recovery.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/recovery/v1/impl/core/utils/RecoveryUtil.java
@@ -373,9 +373,16 @@ public class RecoveryUtil {
                 .buildApiCall(Constants.APICall.RESET_PASSWORD_API.getType(), Constants.RelationStates.NEXT_REL,
                         buildURIForBody(tenantDomain, Constants.APICall.RESET_PASSWORD_API.getApiUrl(),
                                 Constants.ACCOUNT_RECOVERY_ENDPOINT_BASEPATH), null));
-        RetryErrorResponse retryErrorResponse = buildRetryErrorResponse(
-                Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, code, description, resetCode, correlationId,
-                apiCallsArrayList);
+        RetryErrorResponse retryErrorResponse;
+        if (isNormalizedRetryErrorResponseEnabled()) {
+            retryErrorResponse = buildRetryErrorResponse(
+                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, description, code, resetCode, correlationId,
+                    apiCallsArrayList);
+        } else {
+            retryErrorResponse = buildRetryErrorResponse(
+                    Constants.STATUS_PRECONDITION_FAILED_MESSAGE_DEFAULT, code, description, resetCode, correlationId,
+                    apiCallsArrayList);
+        }
         if (StringUtils.isNotBlank(className)) {
             description = String.format("%s : %s - %s", LOG_MESSAGE_PREFIX, className, description);
         }
@@ -573,5 +580,20 @@ public class RecoveryUtil {
         clientErrorMap.put(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_POLICY_VIOLATION.getCode(),
                 RETRY_ERROR_CATEGORY);
         return clientErrorMap;
+    }
+
+    /**
+     * Check whether the normalized retry error response is enabled.
+     *
+     * @return true if the normalized retry error response is enabled, false otherwise.
+     */
+    private static boolean isNormalizedRetryErrorResponseEnabled() {
+
+        boolean isEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
+                Constants.ENABLE_NORMALIZED_RETRY_ERROR_RESPONSE));
+        if (log.isDebugEnabled()) {
+            log.debug("Normalized retry error response enabled: " + isEnabled);
+        }
+        return isEnabled;
     }
 }


### PR DESCRIPTION
## Summary

When password history validation fails during password reset (`POST /api/users/v1/recovery/password/reset`), the HTTP 412 response has `code` and `description` fields transposed: the human-readable message appears in `code` and the error code (`PWR-10005`) appears in `description`.

**Root cause:** the **v1** `RecoveryUtil.buildRetryPasswordResetObject()` calls `buildRetryErrorResponse(message, description, code, ...)` but passed the arguments in the wrong order: `buildRetryErrorResponse(message, code, description, ...)`.

The **v2** API was already fixed in 1cc4857 ("Fix password history violation error response"), which gates the corrected field order behind the opt-in property `Recovery.ErrorMessage.EnableNormalizedRetryErrorResponse` to preserve backward compatibility. This PR brings **v1** in line with that same design — it does **not** modify v2.

## Changes (v1 only)

- Added the `Recovery.ErrorMessage.EnableNormalizedRetryErrorResponse` constant and an `isNormalizedRetryErrorResponseEnabled()` helper, mirroring v2.
- Gated the `buildRetryErrorResponse(...)` call in `buildRetryPasswordResetObject()`:
  - **flag enabled** → corrected order (`description, code`)
  - **flag disabled** → legacy order preserved for backward compatibility

**Response when the flag is enabled (corrected):**
```json
{
  "code": "PWR-10005",
  "description": "This password has been used in recent history. Please choose a different password"
}
```

## Config default consistency

Since this fix is being patched into the products from **7.0.0** onwards, the default of `Recovery.ErrorMessage.EnableNormalizedRetryErrorResponse` needs to be made consistent across fresh installs and upgrades. In `carbon-identity-framework` the value is currently `true` for new installs (`default.json`) but inferred as `false` for in-place upgrades from IS 7.0.0 / 7.1.0 / 7.2.0 (`infer.json`, under `preserve_previous_product_behaviour.version`), which would keep the legacy swapped behaviour on upgraded servers. Those inference entries are being removed so upgraded deployments also fall back to the corrected default (`true`), matching new installs.

## Related Issue

- https://github.com/wso2/product-is/issues/27755

## Test plan

- [ ] Enable password history validation (`passwordHistory.enable=true`, count >= 2)
- [ ] Set `Recovery.ErrorMessage.EnableNormalizedRetryErrorResponse=true`
- [ ] Complete the v1 password recovery flow: `init` -> `recover` -> `confirm` -> `reset` with a previously-used password
- [ ] Verify the HTTP 412 response has `code: "PWR-10005"` and `description` containing the human-readable message
- [ ] Verify that with the property disabled the legacy (unchanged) response is returned
