### PR TITLE
Add getDevicesByUserId() method to fetch registered devices

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
@@ -129,20 +129,15 @@ public class PushDeviceManagementService {
      */
     public List<DeviceDTO> getDevicesByUserId() {
 
-        List<DeviceDTO> deviceDTOList = new ArrayList<>();
         try {
             User user = ContextLoader.getUserFromContext();
             String tenantDomain = user.getTenantDomain();
             String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
             List<Device> devices = deviceHandlerService.getDevicesByUserId(userId, tenantDomain);
-            deviceDTOList = buildListDeviceDTO(devices);
+            return buildListDeviceDTO(devices);
         } catch (PushDeviceHandlerException e) {
-            // If no device registered for the userId, the below-mentioned error is thrown.
-            if (!ERROR_CODE_DEVICE_NOT_FOUND_FOR_USER_ID.getCode().equals(e.getErrorCode())) {
-                throw handlePushDeviceHandlerException(e);
-            }
+            throw handlePushDeviceHandlerException(e);
         }
-        return deviceDTOList;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/core/PushDeviceManagementService.java
@@ -101,7 +101,9 @@ public class PushDeviceManagementService {
      * Get device by user ID.
      *
      * @return Device.
+     * @deprecated Use {@link #getDevicesByUserId()} instead to get all devices for a user.
      */
+    @Deprecated
     public List<DeviceDTO> getDeviceByUserId() {
 
         List<DeviceDTO> deviceDTOList = new ArrayList<>();
@@ -111,6 +113,29 @@ public class PushDeviceManagementService {
             String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
             Device device = deviceHandlerService.getDeviceByUserId(userId, tenantDomain);
             deviceDTOList.add(buildDeviceDTO(device));
+        } catch (PushDeviceHandlerException e) {
+            // If no device registered for the userId, the below-mentioned error is thrown.
+            if (!ERROR_CODE_DEVICE_NOT_FOUND_FOR_USER_ID.getCode().equals(e.getErrorCode())) {
+                throw handlePushDeviceHandlerException(e);
+            }
+        }
+        return deviceDTOList;
+    }
+
+    /**
+     * Get all devices registered for the current user.
+     *
+     * @return List of device DTOs for the current user; empty list if none are registered.
+     */
+    public List<DeviceDTO> getDevicesByUserId() {
+
+        List<DeviceDTO> deviceDTOList = new ArrayList<>();
+        try {
+            User user = ContextLoader.getUserFromContext();
+            String tenantDomain = user.getTenantDomain();
+            String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+            List<Device> devices = deviceHandlerService.getDevicesByUserId(userId, tenantDomain);
+            deviceDTOList = buildListDeviceDTO(devices);
         } catch (PushDeviceHandlerException e) {
             // If no device registered for the userId, the below-mentioned error is thrown.
             if (!ERROR_CODE_DEVICE_NOT_FOUND_FOR_USER_ID.getCode().equals(e.getErrorCode())) {
@@ -200,6 +225,21 @@ public class PushDeviceManagementService {
         deviceDTO.setModel(device.getDeviceModel());
         deviceDTO.setProvider(device.getProvider());
         return deviceDTO;
+    }
+
+    /**
+     * Build a list of device DTOs from the given devices.
+     *
+     * @param deviceList List of devices.
+     * @return List of device DTOs.
+     */
+    private List<DeviceDTO> buildListDeviceDTO(List<Device> deviceList) {
+
+        List<DeviceDTO> deviceDTOList = new ArrayList<>();
+        for (Device device : deviceList) {
+            deviceDTOList.add(buildDeviceDTO(device));
+        }
+        return deviceDTOList;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.push/org.wso2.carbon.identity.rest.api.user.push.v1/src/main/java/org/wso2/carbon/identity/rest/api/user/push/v1/impl/DevicesApiServiceImpl.java
@@ -62,7 +62,7 @@ public class DevicesApiServiceImpl implements DevicesApiService {
     @Override
     public Response getDevices() {
 
-        List<DeviceDTO> deviceDTOList = pushDeviceManagementService.getDeviceByUserId();
+        List<DeviceDTO> deviceDTOList = pushDeviceManagementService.getDevicesByUserId();
         return Response.ok().entity(deviceDTOList).build();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -534,14 +534,14 @@
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <carbon.kernel.version>4.10.25</carbon.kernel.version>
         <identity.governance.version>1.11.60</identity.governance.version>
-        <carbon.identity.framework.version>7.10.17</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.159</carbon.identity.framework.version>
         <carbon.identity.framework.version.range>[5.14.67, 8.0.0]</carbon.identity.framework.version.range>
         <carbon.identity.account.association.version>5.5.10</carbon.identity.account.association.version>
         <maven.spotbugsplugin.version>4.9.8.2</maven.spotbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <identity.oauth.version>7.0.169</identity.oauth.version>
         <identity.org.mgt.core.version>1.1.52</identity.org.mgt.core.version>
-        <identity.notification.push.version>1.1.1</identity.notification.push.version>
+        <identity.notification.push.version>1.2.2</identity.notification.push.version>
         <identity.notification.push.version.range>[1.0.0, 2.0.0)</identity.notification.push.version.range>
         <testng.version>6.9.10</testng.version>
         <fido2.version>6.0.3</fido2.version>


### PR DESCRIPTION
This pull request adds a new method to retrieve devices by user ID and refactors the code to use this new method, improving clarity and maintainability. It also introduces a helper method to build lists of device DTOs from model objects.

**Device retrieval improvements:**

* Added a new `getDevicesByUserId` method in `PushDeviceManagementService` to fetch all devices for the current user, with improved error handling for cases where no devices are found.
* Updated `DevicesApiServiceImpl` to use the new `getDevicesByUserId` method instead of the old one, ensuring consistency and leveraging the improved logic.

**Code modularization:**

* Added a private helper method `buildListDeviceDTO` in `PushDeviceManagementService` to convert a list of `Device` objects into a list of `DeviceDTO` objects, reducing code duplication and improving readability.

**Related Issues**

- https://github.com/wso2/product-is/issues/27801