### PR TITLE
Fix passkey credential resolution to use fully-qualified username

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.credential/org.wso2.carbon.identity.api.user.credential.common/src/main/java/org/wso2/carbon/identity/api/user/credential/common/core/PasskeyCredentialHandler.java
+++ b/components/org.wso2.carbon.identity.api.user.credential/org.wso2.carbon.identity.api.user.credential.common/src/main/java/org/wso2/carbon/identity/api/user/credential/common/core/PasskeyCredentialHandler.java
@@ -61,7 +61,7 @@ public class PasskeyCredentialHandler implements CredentialHandler {
             LOG.debug("Retrieving passkey credentials for user ID: " + userId);
         }
         try {
-            String username = CredentialManagementUtils.resolveUsernameFromUserId(userId);
+            String username = CredentialManagementUtils.resolveUsernameFromUserId(userId).toFullQualifiedUsername();
             Collection<FIDO2CredentialRegistration> passkeyCredentials = webAuthnService
                     .getFIDO2DeviceMetaData(username);
 
@@ -92,7 +92,7 @@ public class PasskeyCredentialHandler implements CredentialHandler {
             LOG.debug("Deleting passkey credential for user ID: " + userId);
         }
         try {
-            String username = CredentialManagementUtils.resolveUsernameFromUserId(userId);
+            String username = CredentialManagementUtils.resolveUsernameFromUserId(userId).toFullQualifiedUsername();
             webAuthnService.deregisterFIDO2Credential(credentialId, username);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Successfully deleted passkey credential for user ID: " + userId);

--- a/components/org.wso2.carbon.identity.api.user.credential/org.wso2.carbon.identity.api.user.credential.common/src/main/java/org/wso2/carbon/identity/api/user/credential/common/utils/CredentialManagementUtils.java
+++ b/components/org.wso2.carbon.identity.api.user.credential/org.wso2.carbon.identity.api.user.credential.common/src/main/java/org/wso2/carbon/identity/api/user/credential/common/utils/CredentialManagementUtils.java
@@ -83,16 +83,15 @@ public class CredentialManagementUtils {
     }
 
     /**
-     * Resolve the fully-qualified username for a given user UUID.
+     * Resolves the username from the given user ID (UUID).
      *
-     * @param userId User ID (UUID).
-     * @return Fully-qualified username.
+     * @param userId User ID (UUID) to resolve the username for.
+     * @return Resolved User object containing the username and other details.
      */
-    public static String resolveUsernameFromUserId(String userId) {
+    public static User resolveUsernameFromUserId(String userId) {
 
         RealmService realmService = CredentialManagementServiceDataHolder.getRealmService();
-        User user = new UniqueIdToUser().apply(realmService, userId, IdentityTenantUtil.resolveTenantDomain());
-        return user.getUserName() + "@" + user.getTenantDomain();
+        return new UniqueIdToUser().apply(realmService, userId, IdentityTenantUtil.resolveTenantDomain());
     }
 
     /**


### PR DESCRIPTION
## Summary

- Added `CredentialManagementService` and fixed user ID validation
- Changed `resolveUsernameFromUserId` in `CredentialManagementUtils` to return the full `User` object instead of a manually concatenated username string
- Updated `PasskeyCredentialHandler` to call `.toFullQualifiedUsername()` at the call sites for get and delete passkey operations, ensuring the tenant domain is correctly included when invoking the WebAuthn service