### PR TITLE
Return element display name in get consent API

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentedElement.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentedElement.java
@@ -31,9 +31,10 @@ import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
 public class ConsentedElement  {
-  
+
     private String id;
     private String name;
+    private String displayName;
 
     /**
     * UUID of the consent element.
@@ -62,7 +63,7 @@ public class ConsentedElement  {
         this.name = name;
         return this;
     }
-    
+
     @ApiModelProperty(example = "Email Address", value = "Name of the consent element.")
     @JsonProperty("name")
     @Valid
@@ -71,6 +72,25 @@ public class ConsentedElement  {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    * Display name of the consent element.
+    **/
+    public ConsentedElement displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Email Address", value = "Display name of the consent element.")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 
 
@@ -86,12 +106,13 @@ public class ConsentedElement  {
         }
         ConsentedElement consentedElement = (ConsentedElement) o;
         return Objects.equals(this.id, consentedElement.id) &&
-            Objects.equals(this.name, consentedElement.name);
+            Objects.equals(this.name, consentedElement.name) &&
+            Objects.equals(this.displayName, consentedElement.displayName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name);
+        return Objects.hash(id, name, displayName);
     }
 
     @Override
@@ -99,9 +120,10 @@ public class ConsentedElement  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class ConsentedElement {\n");
-        
+
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -453,6 +453,9 @@ public class UserConsentService {
                         if (StringUtils.isNotBlank(piiCategory.getUuid())) {
                             element.setId(piiCategory.getUuid());
                         }
+                        if (StringUtils.isNotBlank(piiCategory.getDisplayName())) {
+                            element.setDisplayName(piiCategory.getDisplayName());
+                        }
                     }
                 } catch (ConsentManagementException e) {
                     if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/resources/consent.yaml
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/resources/consent.yaml
@@ -491,6 +491,10 @@ definitions:
         type: string
         description: Name of the consent element.
         example: 'Email Address'
+      displayName:
+        type: string
+        description: Display name of the consent element.
+        example: 'Email Address'
 
   ConsentValidationResponse:
     type: object


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26859

This pull request enhances the `ConsentedElement` model to support a new `displayName` property, ensuring that both the backend model and the API specification can handle and expose a user-friendly display name for consent elements. The changes update the Java model, the OpenAPI definition, and the service logic to set and retrieve this new field.

Model and API enhancements:

* Added a new `displayName` property to the `ConsentedElement` Java class, including getter, setter, and builder methods, and updated the `equals`, `hashCode`, and `toString` methods to incorporate this field. [[1]](diffhunk://#diff-d5e92283f2a039f8e6b639ada6af0530719d7d3ff308457a68b1e99d6f728755R37) [[2]](diffhunk://#diff-d5e92283f2a039f8e6b639ada6af0530719d7d3ff308457a68b1e99d6f728755R77-R95) [[3]](diffhunk://#diff-d5e92283f2a039f8e6b639ada6af0530719d7d3ff308457a68b1e99d6f728755L89-R115) [[4]](diffhunk://#diff-d5e92283f2a039f8e6b639ada6af0530719d7d3ff308457a68b1e99d6f728755R126)
* Updated the OpenAPI definition (`consent.yaml`) to include the `displayName` property for consent elements, with appropriate description and example.

Service logic update:

* Modified the `UserConsentService` to set the `displayName` property on `ConsentedElement` objects when available from the underlying data source.