### PR TITLE
Add methods for self-service API

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -208,8 +208,7 @@ public class UserConsentService {
         String subjectId = ContextLoader.getUsernameFromContext();
 
         try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            validateOwnership(receipt, consentId, subjectId);
+            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
             return toConsentResponse(receipt);
         } catch (ConsentManagementException e) {
             throw handleException(e);
@@ -221,8 +220,7 @@ public class UserConsentService {
         String subjectId = ContextLoader.getUsernameFromContext();
 
         try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            validateOwnership(receipt, consentId, subjectId);
+            consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
             consentManager.authorizeConsent(consentId, subjectId, REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw handleException(e);
@@ -238,9 +236,7 @@ public class UserConsentService {
             String authStatus = requestState != null ? requestState.value() :
                     AuthorizationRequest.StateEnum.APPROVED.value();
 
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId);
-            validateAuthorizer(receipt, consentId, subjectId, authorizations);
+            consentManager.getConsentAuthorizations(consentId, subjectId);
             consentManager.authorizeConsent(consentId, subjectId, authStatus);
         } catch (ConsentManagementException e) {
             throw handleException(e);
@@ -252,8 +248,7 @@ public class UserConsentService {
         String subjectId = ContextLoader.getUsernameFromContext();
 
         try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            validateOwnership(receipt, consentId, subjectId);
+            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
 
             String status = consentManager.validateConsentStatus(consentId);
             ConsentValidationResponse response = new ConsentValidationResponse();
@@ -288,60 +283,6 @@ public class UserConsentService {
             purposeBindings.add(new PurposePIICategoryBinding(purposeInput.getId(), piiCategories));
         }
         return purposeBindings;
-    }
-
-    private void validateOwnership(Receipt receipt, String consentId, String subjectId) {
-
-        if (receipt == null) {
-            throw consentNotFoundError(consentId);
-        }
-        if (!subjectId.equals(receipt.getPiiPrincipalId())) {
-            throw userNotAuthorizedError();
-        }
-    }
-
-    private void validateAuthorizer(Receipt receipt, String consentId, String subjectId,
-                                    List<ConsentAuthorization> authorizations) {
-
-        if (receipt == null) {
-            throw consentNotFoundError(consentId);
-        }
-        if (subjectId.equals(receipt.getPiiPrincipalId())) {
-            return;
-        }
-        if (findUserAuthorization(authorizations, subjectId) != null) {
-            return;
-        }
-        throw userNotAuthorizedError();
-    }
-
-    private ConsentAuthorization findUserAuthorization(List<ConsentAuthorization> authorizations, String subjectId) {
-
-        if (authorizations != null) {
-            for (ConsentAuthorization auth : authorizations) {
-                if (subjectId.equals(auth.getUserId())) {
-                    return auth;
-                }
-            }
-        }
-        return null;
-    }
-
-    private APIError consentNotFoundError(String consentId) {
-
-        return new APIError(Response.Status.NOT_FOUND, new ErrorResponse.Builder()
-                .withCode(ErrorMessages.ERROR_CODE_RECEIPT_ID_INVALID.getCode())
-                .withMessage("Consent not found.")
-                .withDescription("No consent found for ID: " + consentId)
-                .build());
-    }
-
-    private APIError userNotAuthorizedError() {
-
-        return new APIError(Response.Status.FORBIDDEN, new ErrorResponse.Builder()
-                .withCode(ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED.getCode())
-                .withMessage(ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED.getMessage())
-                .build());
     }
 
     private ConsentResponse toConsentResponse(Receipt receipt) {

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <identity.organization.management.version>1.4.122</identity.organization.management.version>
         <openapi-generator-maven-plugin.version>4.1.2</openapi-generator-maven-plugin.version>
         <carbon.workflow-engine.version>1.1.6</carbon.workflow-engine.version>
-        <carbon.consent.mgt.version>2.9.10</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.14</carbon.consent.mgt.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request refactors the consent validation and authorization logic in the `UserConsentService` class to delegate user validation directly to the `ConsentManager` layer, and updates the dependency version for the consent management module. The main changes simplify the service layer by removing redundant validation code and ensuring that user-specific operations are handled at the manager level.

Key changes:

**Refactoring validation and authorization logic:**

* Updated calls to `consentManager.getReceiptWithExtendedSchema` and related methods to include the `subjectId` parameter, allowing the manager to handle user validation directly instead of performing ownership and authorization checks in the service layer.
* Removed the `validateOwnership`, `validateAuthorizer`, and related helper methods from `UserConsentService`, streamlining the code and reducing duplication of validation logic.

**Dependency update:**

* Bumped the `carbon.consent.mgt.version` property in `pom.xml` from `2.9.10` to `2.9.14` to align with the new validation approach and ensure compatibility.