### PR TITLE
Add relation, timestamp filter and attributes to /me consents; allow authorizer access

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/MeApi.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/MeApi.java
@@ -75,7 +75,7 @@ public class MeApi  {
     @Path("/consents/{consent-id}/authorize")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Authorize a consent", notes = "Authorizes a PENDING consent. The authenticated user must be in the consent's authorization list, returns 403 otherwise. When all required users have approved, the consent transitions to ACTIVE state. If any user rejects, the consent transitions to REJECTED state. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Authorize a consent", notes = "Authorizes a PENDING consent. The authenticated user must either be the subject of the consent, or be listed in the consent's authorization list; returns 403 otherwise. When all required users have approved, the consent transitions to ACTIVE state. If any user rejects, the consent transitions to REJECTED state. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -100,7 +100,7 @@ public class MeApi  {
     @Path("/consents/{consent-id}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID. Only the consent subject may retrieve the record. Returns 403 if the authenticated user is not the consent subject. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentResponse.class, authorizations = {
+    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID. The authenticated user must either be the subject of the consent, or be listed in the consent's authorization list; returns 403 otherwise. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -123,7 +123,7 @@ public class MeApi  {
     @Path("/consents")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering. Returns only the authenticated user's own consents. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentSummary.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering. Returns the authenticated user's own consents, or those the user authorizes, based on the `relation` parameter. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentSummary.class, responseContainer = "List", authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -131,12 +131,13 @@ public class MeApi  {
     }, tags={ "me", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Consents retrieved successfully.", response = ConsentSummary.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid input request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
     })
-    public Response listConsentsOfLoggedInUser(    @Valid@ApiParam(value = "Filter consents by service identifier.")  @QueryParam("serviceId") String serviceId,     @Valid@ApiParam(value = "Filter consents by state.", allowableValues="PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED")  @QueryParam("state") String state,     @Valid@ApiParam(value = "Filter consents by purpose UUID.")  @QueryParam("purposeId") String purposeId,     @Valid@ApiParam(value = "Filter consents by specific purpose version UUID.")  @QueryParam("purposeVersionId") String purposeVersionId,     @Valid@ApiParam(value = "Filter consents by custom properties using dot notation `properties.<key>`. Supports 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations. Combine multiple conditions with 'and', 'or' logical operators. Examples: filter=properties.region eq EU ")  @QueryParam("filter") String filter,     @Valid @Min(1)@ApiParam(value = "Maximum number of records to return. Default is 10.", defaultValue="10") @DefaultValue("10")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Cursor for forward pagination. Pass the base64-encoded UUID of the last item received from the previous page to retrieve the next page of results. ")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Cursor for backward pagination. Pass the base64-encoded UUID of the first item received from the current page to retrieve the previous page of results. ")  @QueryParam("before") String before) {
+    public Response listConsentsOfLoggedInUser(    @Valid@ApiParam(value = "Relation of the authenticated user to the retrieved consents. SUBJECT returns consents given by the user, AUTHORIZER returns consents the user is listed as an authorizer of, ANY returns both. ", allowableValues="SUBJECT, AUTHORIZER, ANY", defaultValue="SUBJECT") @DefaultValue("SUBJECT")  @QueryParam("relation") String relation,     @Valid@ApiParam(value = "Filter consents by service identifier.")  @QueryParam("serviceId") String serviceId,     @Valid@ApiParam(value = "Filter consents by state.", allowableValues="PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED")  @QueryParam("state") String state,     @Valid@ApiParam(value = "Filter consents by purpose UUID.")  @QueryParam("purposeId") String purposeId,     @Valid@ApiParam(value = "Filter consents by specific purpose version UUID.")  @QueryParam("purposeVersionId") String purposeVersionId,     @Valid@ApiParam(value = "Filter consents by custom properties using dot notation `properties.<key>`, and by `timestamp` (milliseconds since epoch). Properties support 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations. `timestamp` supports 'ge' (greater than or equals) and 'le' (less than or equals) operations. Combine multiple conditions with the 'and' logical operator. Examples: filter=properties.region eq EU, filter=timestamp ge 1744000000000 and timestamp le 1766383796000 ")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Specifies the required attributes in the response as a comma-separated string. Supported values: `purposes`, `authorizations`, `properties`. Example: attributes=purposes,properties ")  @QueryParam("attributes") String attributes,     @Valid @Min(1)@ApiParam(value = "Maximum number of records to return. Default is 10.", defaultValue="10") @DefaultValue("10")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Cursor for forward pagination. Pass the base64-encoded UUID of the last item received from the previous page to retrieve the next page of results. ")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Cursor for backward pagination. Pass the base64-encoded UUID of the first item received from the current page to retrieve the previous page of results. ")  @QueryParam("before") String before) {
 
-        return delegate.listConsentsOfLoggedInUser(serviceId,  state,  purposeId,  purposeVersionId,  filter,  limit,  after,  before );
+        return delegate.listConsentsOfLoggedInUser(relation,  serviceId,  state,  purposeId,  purposeVersionId,  filter,  attributes,  limit,  after,  before );
     }
 
     @Valid
@@ -144,7 +145,7 @@ public class MeApi  {
     @Path("/consents/{consent-id}/revoke")
     
     @Produces({ "*/*" })
-    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise. Idempotent — if the consent is already revoked, returns 200 with no error. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. The authenticated user must either be the subject of the consent, or be listed in the consent's authorization list; returns 403 otherwise. Idempotent — if the consent is already revoked, returns 200 with no error. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -167,7 +168,7 @@ public class MeApi  {
     @Path("/consents/{consent-id}/validate")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get the current state of a consent object", notes = "Returns the current state of a consent record, performing a lazy expiry check. The authenticated user must be the consent subject, returns 403 otherwise. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentValidationResponse.class, authorizations = {
+    @ApiOperation(value = "Get the current state of a consent object", notes = "Returns the current state of a consent record, performing a lazy expiry check. The authenticated user must either be the subject of the consent, or be listed in the consent's authorization list; returns 403 otherwise. <br> <b>Permission required:</b> <br> * None <br> <b>Scope required:</b> <br> * internal_login ", response = ConsentValidationResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/MeApiService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/MeApiService.java
@@ -43,7 +43,7 @@ public interface MeApiService {
 
       public Response getConsentOfLoggedInUser(String consentId);
 
-      public Response listConsentsOfLoggedInUser(String serviceId, String state, String purposeId, String purposeVersionId, String filter, Integer limit, String after, String before);
+      public Response listConsentsOfLoggedInUser(String relation, String serviceId, String state, String purposeId, String purposeVersionId, String filter, String attributes, Integer limit, String after, String before);
 
       public Response revokeConsentOfLoggedInUser(String consentId);
 

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentPurposeSummary.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentPurposeSummary.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.user.consent.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Minimal consented purpose information for list responses.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Minimal consented purpose information for list responses.")
+public class ConsentPurposeSummary  {
+  
+    private String id;
+    private String name;
+    private String type;
+    private String versionId;
+    private String version;
+
+    /**
+    * UUID of the purpose.
+    **/
+    public ConsentPurposeSummary id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "a43f8d09-2e1f-4b3a-9f6e-3a1b2c4d5e6f", value = "UUID of the purpose.")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    * Name of the purpose.
+    **/
+    public ConsentPurposeSummary name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Marketing communications", value = "Name of the purpose.")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    * Purpose type classification.
+    **/
+    public ConsentPurposeSummary type(String type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Policy", value = "Purpose type classification.")
+    @JsonProperty("type")
+    @Valid
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+    * UUID of the purpose version consented to.
+    **/
+    public ConsentPurposeSummary versionId(String versionId) {
+
+        this.versionId = versionId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b53g9e10-3f2g-5c4b-0g7f-4b2c3d5e6f7g", value = "UUID of the purpose version consented to.")
+    @JsonProperty("versionId")
+    @Valid
+    public String getVersionId() {
+        return versionId;
+    }
+    public void setVersionId(String versionId) {
+        this.versionId = versionId;
+    }
+
+    /**
+    * Human-readable version label.
+    **/
+    public ConsentPurposeSummary version(String version) {
+
+        this.version = version;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2", value = "Human-readable version label.")
+    @JsonProperty("version")
+    @Valid
+    public String getVersion() {
+        return version;
+    }
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsentPurposeSummary consentPurposeSummary = (ConsentPurposeSummary) o;
+        return Objects.equals(this.id, consentPurposeSummary.id) &&
+            Objects.equals(this.name, consentPurposeSummary.name) &&
+            Objects.equals(this.type, consentPurposeSummary.type) &&
+            Objects.equals(this.versionId, consentPurposeSummary.versionId) &&
+            Objects.equals(this.version, consentPurposeSummary.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, type, versionId, version);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConsentPurposeSummary {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    versionId: ").append(toIndentedString(versionId)).append("\n");
+        sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentSummary.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/gen/java/org/wso2/carbon/identity/api/user/consent/v1/model/ConsentSummary.java
@@ -22,6 +22,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.wso2.carbon.identity.api.user.consent.v1.model.AuthorizationResponse;
+import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentPurposeSummary;
 import javax.validation.constraints.*;
 
 
@@ -33,6 +39,7 @@ import javax.xml.bind.annotation.*;
 public class ConsentSummary  {
   
     private String id;
+    private String subjectId;
     private String serviceId;
 
 @XmlType(name="StateEnum")
@@ -69,6 +76,12 @@ public enum StateEnum {
 
     private StateEnum state;
     private Long timestamp;
+    private List<ConsentPurposeSummary> purposes = null;
+
+    private List<AuthorizationResponse> authorizations = null;
+
+    private Map<String, String> properties = null;
+
 
     /**
     * Unique identifier of the consent.
@@ -87,6 +100,25 @@ public enum StateEnum {
     }
     public void setId(String id) {
         this.id = id;
+    }
+
+    /**
+    * Identifier of the user who gave consent.
+    **/
+    public ConsentSummary subjectId(String subjectId) {
+
+        this.subjectId = subjectId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "john", value = "Identifier of the user who gave consent.")
+    @JsonProperty("subjectId")
+    @Valid
+    public String getSubjectId() {
+        return subjectId;
+    }
+    public void setSubjectId(String subjectId) {
+        this.subjectId = subjectId;
     }
 
     /**
@@ -146,7 +178,89 @@ public enum StateEnum {
         this.timestamp = timestamp;
     }
 
+    /**
+    * List of purposes included in the consent. Returned only when requested via &#x60;attributes&#x60;.
+    **/
+    public ConsentSummary purposes(List<ConsentPurposeSummary> purposes) {
 
+        this.purposes = purposes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "List of purposes included in the consent. Returned only when requested via `attributes`.")
+    @JsonProperty("purposes")
+    @Valid
+    public List<ConsentPurposeSummary> getPurposes() {
+        return purposes;
+    }
+    public void setPurposes(List<ConsentPurposeSummary> purposes) {
+        this.purposes = purposes;
+    }
+
+    public ConsentSummary addPurposesItem(ConsentPurposeSummary purposesItem) {
+        if (this.purposes == null) {
+            this.purposes = new ArrayList<>();
+        }
+        this.purposes.add(purposesItem);
+        return this;
+    }
+
+        /**
+    * Authorization records associated with this consent. Returned only when requested via &#x60;attributes&#x60;.
+    **/
+    public ConsentSummary authorizations(List<AuthorizationResponse> authorizations) {
+
+        this.authorizations = authorizations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Authorization records associated with this consent. Returned only when requested via `attributes`.")
+    @JsonProperty("authorizations")
+    @Valid
+    public List<AuthorizationResponse> getAuthorizations() {
+        return authorizations;
+    }
+    public void setAuthorizations(List<AuthorizationResponse> authorizations) {
+        this.authorizations = authorizations;
+    }
+
+    public ConsentSummary addAuthorizationsItem(AuthorizationResponse authorizationsItem) {
+        if (this.authorizations == null) {
+            this.authorizations = new ArrayList<>();
+        }
+        this.authorizations.add(authorizationsItem);
+        return this;
+    }
+
+        /**
+    * Properties associated with this consent. Returned only when requested via &#x60;attributes&#x60;.
+    **/
+    public ConsentSummary properties(Map<String, String> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Properties associated with this consent. Returned only when requested via `attributes`.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public ConsentSummary putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -159,14 +273,18 @@ public enum StateEnum {
         }
         ConsentSummary consentSummary = (ConsentSummary) o;
         return Objects.equals(this.id, consentSummary.id) &&
+            Objects.equals(this.subjectId, consentSummary.subjectId) &&
             Objects.equals(this.serviceId, consentSummary.serviceId) &&
             Objects.equals(this.state, consentSummary.state) &&
-            Objects.equals(this.timestamp, consentSummary.timestamp);
+            Objects.equals(this.timestamp, consentSummary.timestamp) &&
+            Objects.equals(this.purposes, consentSummary.purposes) &&
+            Objects.equals(this.authorizations, consentSummary.authorizations) &&
+            Objects.equals(this.properties, consentSummary.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, serviceId, state, timestamp);
+        return Objects.hash(id, subjectId, serviceId, state, timestamp, purposes, authorizations, properties);
     }
 
     @Override
@@ -176,9 +294,13 @@ public enum StateEnum {
         sb.append("class ConsentSummary {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    subjectId: ").append(toIndentedString(subjectId)).append("\n");
         sb.append("    serviceId: ").append(toIndentedString(serviceId)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+        sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
+        sb.append("    authorizations: ").append(toIndentedString(authorizations)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/MeApiServiceImpl.java
@@ -66,12 +66,12 @@ public class MeApiServiceImpl implements MeApiService {
     }
 
     @Override
-    public Response listConsentsOfLoggedInUser(String serviceId, String state, String purposeId,
-                                               String purposeVersionId, String filter,
+    public Response listConsentsOfLoggedInUser(String relation, String serviceId, String state, String purposeId,
+                                               String purposeVersionId, String filter, String attributes,
                                                Integer limit, String after, String before) {
 
         List<ConsentSummary> summaries = userConsentService.listConsents(
-                serviceId, state, purposeId, purposeVersionId, filter, limit, after, before);
+                relation, serviceId, state, purposeId, purposeVersionId, filter, limit, after, before);
         return Response.ok(summaries).build();
     }
 

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/MeApiServiceImpl.java
@@ -71,7 +71,7 @@ public class MeApiServiceImpl implements MeApiService {
                                                Integer limit, String after, String before) {
 
         List<ConsentSummary> summaries = userConsentService.listConsents(
-                relation, serviceId, state, purposeId, purposeVersionId, filter, limit, after, before);
+                relation, serviceId, state, purposeId, purposeVersionId, filter, attributes, limit, after, before);
         return Response.ok(summaries).build();
     }
 

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -175,11 +175,19 @@ public class UserConsentService {
                         FilterConstants.FILTER_ATTR_BEFORE.equals(attr)) {
                     continue;
                 }
+                String op = node.getOperation() != null ? node.getOperation().toLowerCase(Locale.ROOT) : "";
+                if (FilterConstants.FILTER_ATTR_TIMESTAMP.equals(attr)) {
+                    if (!("ge".equals(op) || "le".equals(op))) {
+                        throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
+                                "Only 'ge' and 'le' operations are supported for consent timestamp filter.");
+                    }
+                    continue;
+                }
                 if (attr == null || !attr.startsWith("properties.") || attr.length() <= "properties.".length()) {
                     throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
-                            "Only 'properties.<key>' attributes are supported in consent filter. Got: " + attr);
+                            "Only 'properties.<key>' and 'timestamp' attributes are supported in consent filter. "
+                                    + "Got: " + attr);
                 }
-                String op = node.getOperation() != null ? node.getOperation().toLowerCase(Locale.ROOT) : "";
                 if (!("eq".equals(op) || "sw".equals(op) || "co".equals(op) || "ew".equals(op))) {
                     throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
                             "Only 'eq', 'sw', 'co', and 'ew' operations are supported for consent property filter.");

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -490,6 +490,7 @@ public class UserConsentService {
 
         ConsentSummary summary = new ConsentSummary();
         summary.setId(receipt.getConsentReceiptId());
+        summary.setSubjectId(receipt.getPiiPrincipalId());
         summary.setTimestamp(receipt.getConsentTimestamp());
         summary.setState(ConsentSummary.StateEnum.fromValue(receipt.getState()));
         if (receipt.getServices() != null && !receipt.getServices().isEmpty()) {

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.consent.mgt.core.model.AddReceiptResponse;
 import org.wso2.carbon.consent.mgt.core.model.ConsentAuthorization;
 import org.wso2.carbon.consent.mgt.core.model.ConsentPurpose;
+import org.wso2.carbon.consent.mgt.core.model.ConsentRelation;
 import org.wso2.carbon.consent.mgt.core.model.PIICategory;
 import org.wso2.carbon.consent.mgt.core.model.PIICategoryValidity;
 import org.wso2.carbon.consent.mgt.core.model.Purpose;
@@ -141,13 +142,14 @@ public class UserConsentService {
         }
     }
 
-    public List<ConsentSummary> listConsents(String serviceId, String state, String purposeId,
+    public List<ConsentSummary> listConsents(String relation, String serviceId, String state, String purposeId,
                                              String purposeVersionId, String filter,
                                              Integer limit, String after, String before) {
 
-        String subjectId = ContextLoader.getUsernameFromContext();
+        String userId = ContextLoader.getUsernameFromContext();
 
         try {
+            ConsentRelation consentRelation = resolveRelation(relation);
             int resolvedLimit = limit != null ? limit : 10;
             if (resolvedLimit <= 0) {
                 throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, String.valueOf(resolvedLimit));
@@ -185,7 +187,8 @@ public class UserConsentService {
             }
 
             List<Receipt> receipts = consentManager.listReceipts(
-                    subjectId, serviceId, state, purposeId, purposeVersionId, expressionNodes, resolvedLimit + 1);
+                    userId, consentRelation, serviceId, state, purposeId, purposeVersionId, expressionNodes,
+                    resolvedLimit + 1);
 
             if (receipts != null && receipts.size() > resolvedLimit) {
                 receipts = new ArrayList<>(receipts.subList(0, resolvedLimit));
@@ -257,6 +260,18 @@ public class UserConsentService {
             return response;
         } catch (ConsentManagementException e) {
             throw handleException(e);
+        }
+    }
+
+    private ConsentRelation resolveRelation(String relation) throws ConsentManagementClientException {
+
+        if (StringUtils.isBlank(relation)) {
+            return ConsentRelation.SUBJECT;
+        }
+        try {
+            return ConsentRelation.valueOf(relation.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, "relation: " + relation);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -153,6 +153,20 @@ public class UserConsentService {
         }
     }
 
+    /**
+     * @deprecated Use
+     * {@link #listConsents(String, String, String, String, String, String, String, Integer, String, String)}
+     * instead.
+     */
+    @Deprecated
+    public List<ConsentSummary> listConsents(String serviceId, String state, String purposeId,
+                                             String purposeVersionId, String filter,
+                                             Integer limit, String after, String before) {
+
+        return listConsents(ConsentRelation.SUBJECT.name(), serviceId, state, purposeId, purposeVersionId, filter,
+                null, limit, after, before);
+    }
+
     public List<ConsentSummary> listConsents(String relation, String serviceId, String state, String purposeId,
                                              String purposeVersionId, String filter, String attributes,
                                              Integer limit, String after, String before) {

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -216,10 +216,10 @@ public class UserConsentService {
 
     public ConsentResponse getConsent(String consentId) {
 
-        String subjectId = ContextLoader.getUsernameFromContext();
+        String userId = ContextLoader.getUsernameFromContext();
 
         try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
+            Receipt receipt = consentManager.getReceiptForInvolvedUserWithExtendedSchema(consentId, userId);
             return toConsentResponse(receipt);
         } catch (ConsentManagementException e) {
             throw handleException(e);
@@ -228,11 +228,11 @@ public class UserConsentService {
 
     public void revokeConsent(String consentId) {
 
-        String subjectId = ContextLoader.getUsernameFromContext();
+        String userId = ContextLoader.getUsernameFromContext();
 
         try {
-            consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
-            consentManager.authorizeConsent(consentId, subjectId, REVOKE_STATE);
+            consentManager.getReceiptForInvolvedUserWithExtendedSchema(consentId, userId);
+            consentManager.authorizeConsent(consentId, userId, REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw handleException(e);
         }
@@ -256,10 +256,10 @@ public class UserConsentService {
 
     public ConsentValidationResponse validateConsent(String consentId) {
 
-        String subjectId = ContextLoader.getUsernameFromContext();
+        String userId = ContextLoader.getUsernameFromContext();
 
         try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId, subjectId);
+            Receipt receipt = consentManager.getReceiptForInvolvedUserWithExtendedSchema(consentId, userId);
 
             String status = consentManager.validateConsentStatus(consentId);
             ConsentValidationResponse response = new ConsentValidationResponse();

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/java/org/wso2/carbon/identity/api/user/consent/v1/impl/core/UserConsentService.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentCreateResponse;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentInput;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentPurposeInput;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentPurposeResponse;
+import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentPurposeSummary;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentResponse;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentSummary;
 import org.wso2.carbon.identity.api.user.consent.v1.model.ConsentValidationResponse;
@@ -59,7 +60,10 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -81,6 +85,13 @@ import static org.wso2.carbon.consent.mgt.core.util.ConsentUtils.handleClientExc
 public class UserConsentService {
 
     private static final Log LOG = LogFactory.getLog(UserConsentService.class);
+
+    private static final String ATTRIBUTE_PURPOSES = "purposes";
+    private static final String ATTRIBUTE_AUTHORIZATIONS = "authorizations";
+    private static final String ATTRIBUTE_PROPERTIES = "properties";
+
+    private static final Set<String> SUPPORTED_CONSENT_ATTRIBUTES = new HashSet<>(Arrays.asList(
+            ATTRIBUTE_PURPOSES, ATTRIBUTE_AUTHORIZATIONS, ATTRIBUTE_PROPERTIES));
 
     private static final Set<String> NOT_FOUND_ERROR_CODES = new HashSet<>(Arrays.asList(
             ErrorMessages.ERROR_CODE_RECEIPT_ID_INVALID.getCode(),
@@ -143,13 +154,14 @@ public class UserConsentService {
     }
 
     public List<ConsentSummary> listConsents(String relation, String serviceId, String state, String purposeId,
-                                             String purposeVersionId, String filter,
+                                             String purposeVersionId, String filter, String attributes,
                                              Integer limit, String after, String before) {
 
         String userId = ContextLoader.getUsernameFromContext();
 
         try {
             ConsentRelation consentRelation = resolveRelation(relation);
+            Set<String> requestedAttributes = resolveAttributes(attributes);
             int resolvedLimit = limit != null ? limit : 10;
             if (resolvedLimit <= 0) {
                 throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, String.valueOf(resolvedLimit));
@@ -208,6 +220,7 @@ public class UserConsentService {
                     summaries.add(toConsentSummary(receipt));
                 }
             }
+            populateRequestedAttributes(summaries, requestedAttributes);
             return summaries;
         } catch (ConsentManagementException e) {
             throw handleException(e);
@@ -269,6 +282,25 @@ public class UserConsentService {
         } catch (ConsentManagementException e) {
             throw handleException(e);
         }
+    }
+
+    private Set<String> resolveAttributes(String attributes) throws ConsentManagementClientException {
+
+        if (StringUtils.isBlank(attributes)) {
+            return Collections.emptySet();
+        }
+        Set<String> resolved = new LinkedHashSet<>();
+        for (String attribute : attributes.split(",")) {
+            String resolvedAttribute = attribute.trim().toLowerCase(Locale.ROOT);
+            if (StringUtils.isBlank(resolvedAttribute)) {
+                continue;
+            }
+            if (!SUPPORTED_CONSENT_ATTRIBUTES.contains(resolvedAttribute)) {
+                throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, "attributes: " + attribute.trim());
+            }
+            resolved.add(resolvedAttribute);
+        }
+        return resolved;
     }
 
     private ConsentRelation resolveRelation(String relation) throws ConsentManagementClientException {
@@ -334,25 +366,8 @@ public class UserConsentService {
 
         List<AuthorizationResponse> authResponses = new ArrayList<>();
         try {
-            List<ConsentAuthorization> auths = consentManager.getConsentAuthorizations(receipt.getConsentReceiptId());
-            if (auths != null) {
-                for (ConsentAuthorization auth : auths) {
-                    if (PENDING_STATE.equals(auth.getStatus().name())) {
-                        continue;
-                    }
-                    try {
-                        AuthorizationResponse authResponse = new AuthorizationResponse();
-                        authResponse.setUserId(auth.getUserId());
-                        authResponse.setState(AuthorizationResponse.StateEnum.fromValue(auth.getStatus().name()));
-                        authResponse.setUpdatedTime(auth.getUpdatedTime());
-                        authResponses.add(authResponse);
-                    } catch (IllegalArgumentException e) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Skipping unrecognized authorization state: " + auth.getStatus(), e);
-                        }
-                    }
-                }
-            }
+            authResponses = toAuthorizationResponses(
+                    consentManager.getConsentAuthorizations(receipt.getConsentReceiptId()));
         } catch (ConsentManagementException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Could not retrieve authorizations for consent: " + receipt.getConsentReceiptId(), e);
@@ -360,6 +375,30 @@ public class UserConsentService {
         }
         dto.setAuthorizations(authResponses);
         return dto;
+    }
+
+    private List<AuthorizationResponse> toAuthorizationResponses(List<ConsentAuthorization> auths) {
+
+        List<AuthorizationResponse> authResponses = new ArrayList<>();
+        if (auths != null) {
+            for (ConsentAuthorization auth : auths) {
+                if (PENDING_STATE.equals(auth.getStatus().name())) {
+                    continue;
+                }
+                try {
+                    AuthorizationResponse authResponse = new AuthorizationResponse();
+                    authResponse.setUserId(auth.getUserId());
+                    authResponse.setState(AuthorizationResponse.StateEnum.fromValue(auth.getStatus().name()));
+                    authResponse.setUpdatedTime(auth.getUpdatedTime());
+                    authResponses.add(authResponse);
+                } catch (IllegalArgumentException e) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Skipping unrecognized authorization state: " + auth.getStatus(), e);
+                    }
+                }
+            }
+        }
+        return authResponses;
     }
 
     private ConsentPurposeResponse toConsentPurposeResponse(ConsentPurpose consentPurpose) {
@@ -443,6 +482,53 @@ public class UserConsentService {
             summary.setServiceId(receipt.getServices().get(0).getService());
         }
         return summary;
+    }
+
+    private void populateRequestedAttributes(List<ConsentSummary> summaries, Set<String> attributes)
+            throws ConsentManagementException {
+
+        if (attributes.isEmpty() || summaries.isEmpty()) {
+            return;
+        }
+        List<String> receiptIds = new ArrayList<>();
+        for (ConsentSummary summary : summaries) {
+            receiptIds.add(summary.getId());
+        }
+        Map<String, List<ConsentPurpose>> purposes = attributes.contains(ATTRIBUTE_PURPOSES)
+                ? consentManager.listConsentPurposes(receiptIds) : Collections.emptyMap();
+        Map<String, List<ConsentAuthorization>> authorizations = attributes.contains(ATTRIBUTE_AUTHORIZATIONS)
+                ? consentManager.listConsentAuthorizations(receiptIds) : Collections.emptyMap();
+        Map<String, Map<String, String>> properties = attributes.contains(ATTRIBUTE_PROPERTIES)
+                ? consentManager.listReceiptProperties(receiptIds) : Collections.emptyMap();
+
+        for (ConsentSummary summary : summaries) {
+            if (attributes.contains(ATTRIBUTE_PURPOSES)) {
+                summary.setPurposes(toConsentPurposeSummaries(
+                        purposes.getOrDefault(summary.getId(), Collections.emptyList())));
+            }
+            if (attributes.contains(ATTRIBUTE_AUTHORIZATIONS)) {
+                summary.setAuthorizations(toAuthorizationResponses(
+                        authorizations.getOrDefault(summary.getId(), Collections.emptyList())));
+            }
+            if (attributes.contains(ATTRIBUTE_PROPERTIES)) {
+                summary.setProperties(properties.getOrDefault(summary.getId(), new HashMap<>()));
+            }
+        }
+    }
+
+    private List<ConsentPurposeSummary> toConsentPurposeSummaries(List<ConsentPurpose> consentPurposes) {
+
+        List<ConsentPurposeSummary> purposeSummaries = new ArrayList<>();
+        for (ConsentPurpose consentPurpose : consentPurposes) {
+            ConsentPurposeSummary purposeSummary = new ConsentPurposeSummary();
+            purposeSummary.setName(consentPurpose.getPurpose());
+            purposeSummary.setId(consentPurpose.getUuid());
+            purposeSummary.setType(consentPurpose.getGroupType());
+            purposeSummary.setVersionId(consentPurpose.getPurposeVersionId());
+            purposeSummary.setVersion(consentPurpose.getVersion());
+            purposeSummaries.add(purposeSummary);
+        }
+        return purposeSummaries;
     }
 
     private APIError handleException(ConsentManagementException e) {

--- a/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/resources/consent.yaml
+++ b/components/org.wso2.carbon.identity.api.user.consent/org.wso2.carbon.identity.api.user.consent.v1/src/main/resources/consent.yaml
@@ -72,7 +72,8 @@ paths:
       summary: List consent records
       description: >
         Retrieve consent records with optional filtering.
-        Returns only the authenticated user's own consents. <br>
+        Returns the authenticated user's own consents, or those the user authorizes, based on
+        the `relation` parameter. <br>
         <b>Permission required:</b> <br>
         * None <br>
         <b>Scope required:</b> <br>
@@ -81,11 +82,13 @@ paths:
       produces:
         - application/json
       parameters:
+        - $ref: '#/parameters/relationQueryParam'
         - $ref: '#/parameters/serviceIdQueryParam'
         - $ref: '#/parameters/stateQueryParam'
         - $ref: '#/parameters/purposeIdQueryParam'
         - $ref: '#/parameters/purposeVersionIdQueryParam'
         - $ref: '#/parameters/filterQueryParam'
+        - $ref: '#/parameters/attributesQueryParam'
         - $ref: '#/parameters/limitQueryParam'
         - $ref: '#/parameters/afterQueryParam'
         - $ref: '#/parameters/beforeQueryParam'
@@ -96,6 +99,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ConsentSummary'
+        400:
+          $ref: '#/responses/InvalidInput'
         401:
           $ref: '#/responses/Unauthorized'
         500:
@@ -108,7 +113,8 @@ paths:
       summary: Get a consent record
       description: >
         Retrieve a specific consent record by consent ID.
-        Only the consent subject may retrieve the record. Returns 403 if the authenticated user is not the consent subject. <br>
+        The authenticated user must either be the subject of the consent,
+        or be listed in the consent's authorization list; returns 403 otherwise. <br>
         <b>Permission required:</b> <br>
         * None <br>
         <b>Scope required:</b> <br>
@@ -138,7 +144,8 @@ paths:
         - me
       summary: Revoke a consent
       description: >
-        Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise.
+        Revokes the consent. The authenticated user must either be the subject of the consent,
+        or be listed in the consent's authorization list; returns 403 otherwise.
         Idempotent — if the consent is already revoked, returns 200 with no error. <br>
         <b>Permission required:</b> <br>
         * None <br>
@@ -165,7 +172,7 @@ paths:
         - me
       summary: Authorize a consent
       description: >
-        Authorizes a PENDING consent. The authenticated user must either be the subject  of the consent,
+        Authorizes a PENDING consent. The authenticated user must either be the subject of the consent,
         or be listed in the consent's authorization list; returns 403 otherwise.
         When all required users have approved, the consent transitions to ACTIVE state.
         If any user rejects, the consent transitions to REJECTED state. <br>
@@ -209,7 +216,8 @@ paths:
       summary: Get the current state of a consent object
       description: >
         Returns the current state of a consent record, performing a lazy expiry check.
-        The authenticated user must be the consent subject, returns 403 otherwise. <br>
+        The authenticated user must either be the subject of the consent,
+        or be listed in the consent's authorization list; returns 403 otherwise. <br>
         <b>Permission required:</b> <br>
         * None <br>
         <b>Scope required:</b> <br>
@@ -351,6 +359,10 @@ definitions:
         type: string
         description: Unique identifier of the consent.
         example: 'd75i1g32-5h4i-7e6d-2i9h-6d4e5f7g8h9i'
+      subjectId:
+        type: string
+        description: Identifier of the user who gave consent.
+        example: 'john'
       serviceId:
         type: string
         description: Identifier of the service the consent was given for.
@@ -370,6 +382,22 @@ definitions:
         format: int64
         description: Milliseconds since epoch when the consent was created.
         example: 1750156200000
+      purposes:
+        type: array
+        description: List of purposes included in the consent. Returned only when requested via `attributes`.
+        items:
+          $ref: '#/definitions/ConsentPurposeSummary'
+      authorizations:
+        type: array
+        description: Authorization records associated with this consent. Returned only when requested via `attributes`.
+        items:
+          $ref: '#/definitions/AuthorizationResponse'
+      properties:
+        type: object
+        x-nullable: true
+        description: Properties associated with this consent. Returned only when requested via `attributes`.
+        additionalProperties:
+          type: string
 
   ConsentCreateResponse:
     type: object
@@ -480,6 +508,32 @@ definitions:
         additionalProperties:
           type: string
 
+  ConsentPurposeSummary:
+    type: object
+    description: Minimal consented purpose information for list responses.
+    properties:
+      id:
+        type: string
+        description: UUID of the purpose.
+        example: 'a43f8d09-2e1f-4b3a-9f6e-3a1b2c4d5e6f'
+      name:
+        type: string
+        description: Name of the purpose.
+        example: 'Marketing communications'
+      type:
+        type: string
+        description: Purpose type classification.
+        example: 'Policy'
+      versionId:
+        type: string
+        description: UUID of the purpose version consented to.
+        example: 'b53g9e10-3f2g-5c4b-0g7f-4b2c3d5e6f7g'
+      version:
+        type: string
+        x-nullable: true
+        description: Human-readable version label.
+        example: '2'
+
   ConsentedElement:
     type: object
     properties:
@@ -588,6 +642,19 @@ parameters:
     format: int32
     default: 10
     minimum: 1
+  relationQueryParam:
+    in: query
+    name: relation
+    required: false
+    description: >
+      Relation of the authenticated user to the retrieved consents. SUBJECT returns consents given
+      by the user, AUTHORIZER returns consents the user is listed as an authorizer of, ANY returns both.
+    type: string
+    default: SUBJECT
+    enum:
+      - SUBJECT
+      - AUTHORIZER
+      - ANY
   serviceIdQueryParam:
     in: query
     name: serviceId
@@ -639,10 +706,22 @@ parameters:
     name: filter
     required: false
     description: >
-      Filter consents by custom properties using dot notation `properties.<key>`.
-      Supports 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations.
-      Combine multiple conditions with 'and', 'or' logical operators.
-      Examples: filter=properties.region eq EU
+      Filter consents by custom properties using dot notation `properties.<key>`, and by
+      `timestamp` (milliseconds since epoch).
+      Properties support 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations.
+      `timestamp` supports 'ge' (greater than or equals) and 'le' (less than or equals) operations.
+      Combine multiple conditions with the 'and' logical operator.
+      Examples: filter=properties.region eq EU,
+      filter=timestamp ge 1744000000000 and timestamp le 1766383796000
+    type: string
+  attributesQueryParam:
+    in: query
+    name: attributes
+    required: false
+    description: >
+      Specifies the required attributes in the response as a comma-separated string.
+      Supported values: `purposes`, `authorizations`, `properties`.
+      Example: attributes=purposes,properties
     type: string
 
 #---------------------

--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <identity.organization.management.version>1.4.122</identity.organization.management.version>
         <openapi-generator-maven-plugin.version>4.1.2</openapi-generator-maven-plugin.version>
         <carbon.workflow-engine.version>1.1.6</carbon.workflow-engine.version>
-        <carbon.consent.mgt.version>2.9.14</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.20</carbon.consent.mgt.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Purpose

Brings the consent delegation model to the self-service API: a user can now list consents they authorize as well as those they gave, filter by creation time, expand list responses selectively, and read, validate and revoke a consent they are a listed authorizer of.

Related Issue: https://github.com/wso2/product-is/issues/28322
Merge After: https://github.com/wso2/carbon-consent-management/pull/285

## API changes

`GET /me/consents`

| Parameter | Change |
|---|---|
| `relation` | New. `SUBJECT` (default) \| `AUTHORIZER` \| `ANY`. |
| `attributes` | New. Comma-separated: `purposes`, `authorizations`, `properties`. |
| `filter` | Now also accepts `timestamp` with `ge` / `le` (milliseconds since epoch). |

`ConsentSummary` gains `subjectId`, plus optional `purposes`, `authorizations` and `properties` populated only when requested via `attributes`. With `relation=AUTHORIZER` or `ANY`, `subjectId` identifies the user who gave the consent, which may be someone other than the caller.

A `400` response is now documented on the listing operation.

`GET`, `POST /revoke` and `POST /validate` on `/me/consents/{consent-id}` now admit the consent subject **or** any user in the consent's authorization list; an unrelated user still receives 403. This means a listed authorizer can revoke the whole consent, including one who never approved it.

## Changes

- `consent.yaml` updated; `src/gen` regenerated (new `ConsentPurposeSummary`, extended `ConsentSummary`).
- `MeApiServiceImpl` passes `relation` and `attributes` through.
- `UserConsentService`:
  - `listConsents` takes `relation` (parsed to `ConsentRelation`, defaulting to `SUBJECT` when blank) and `attributes`; the context username is passed as the user identifier.
  - `timestamp` accepted in the filter attribute check, restricted to `ge` / `le`.
  - `attributes` parsed into a set, unknown values rejected with `400 CM_00118`.
  - Requested attributes populated through the batch lookups from the core PR; no extra queries when `attributes` is omitted.
  - `getConsent`, `revokeConsent` and `validateConsent` now call `getReceiptForInvolvedUserWithExtendedSchema`.
  - `subjectId` set on `ConsentSummary`.
  - Authorization response mapping extracted into a reusable `toAuthorizationResponses`.