### PR TITLE
[identity-api-user] Bump Jackson to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,9 +522,9 @@
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <jackson-jaxrs-json-provider.version>2.21.2</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.21.2</jackson-databind.version>
-        <jackson-dataformat-xml.version>2.21.2</jackson-dataformat-xml.version>
+        <jackson-jaxrs-json-provider.version>2.22.2</jackson-jaxrs-json-provider.version>
+        <jackson-databind.version>2.22.2</jackson-databind.version>
+        <jackson-dataformat-xml.version>2.22.2</jackson-dataformat-xml.version>
         <cxf-bundle.version>3.5.9</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>


### PR DESCRIPTION
## Purpose

Upgrade the Jackson artifacts to the latest stable 2.x release, `2.22.2`.

`2.21.2` is still within the affected range of GHSA-r7wm-3cxj-wff9 (`[2.19.0, 2.21.4)`), which is
the follow-up to CVE-2026-18401 and is described upstream as an incomplete fix for it. `2.22.2` is
the current latest on the 2.x line and is clear of both.

## Approach

Version property bumps only — no code or logic changes.

`pom.xml`:

- `jackson-databind.version`: `2.21.2` → `2.22.2`
- `jackson-jaxrs-json-provider.version`: `2.21.2` → `2.22.2`
- `jackson-dataformat-xml.version`: `2.21.2` → `2.22.2`

> `jackson.version` (`1.9.13`) is the legacy Codehaus Jackson 1.x, a different artifact, and is left
> untouched.
